### PR TITLE
Feature/tok purge

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/services/docker"
+	"github.com/ironstar-io/tokaido/services/unison"
 	"github.com/ironstar-io/tokaido/system/ssh"
 	"github.com/ironstar-io/tokaido/utils"
 	"github.com/spf13/cobra"
@@ -18,6 +20,8 @@ var ExecCmd = &cobra.Command{
 		utils.CheckCmdHard("docker-compose")
 
 		docker.HardCheckTokCompose()
+
+		unison.BackgroundServiceWarning(conf.GetConfig().Tokaido.Project.Name)
 
 		r := ssh.ConnectCommand(args)
 		fmt.Println(r)

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/services/docker"
+	"github.com/ironstar-io/tokaido/services/unison"
 	"github.com/ironstar-io/tokaido/utils"
 	"github.com/spf13/cobra"
 )
@@ -15,6 +17,8 @@ var LogsCmd = &cobra.Command{
 		utils.CheckCmdHard("docker-compose")
 
 		docker.HardCheckTokCompose()
+
+		unison.BackgroundServiceWarning(conf.GetConfig().Tokaido.Project.Name)
 
 		docker.PrintLogs(args)
 	},

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
+	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/services/docker"
+	"github.com/ironstar-io/tokaido/services/unison"
 	"github.com/ironstar-io/tokaido/system"
 	"github.com/ironstar-io/tokaido/utils"
-
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +18,8 @@ var OpenCmd = &cobra.Command{
 		utils.CheckCmdHard("docker-compose")
 
 		docker.HardCheckTokCompose()
+
+		unison.BackgroundServiceWarning(conf.GetConfig().Tokaido.Project.Name)
 
 		system.OpenSite(args)
 	},

--- a/cmd/ports.go
+++ b/cmd/ports.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/services/docker"
+	"github.com/ironstar-io/tokaido/services/unison"
 	"github.com/ironstar-io/tokaido/utils"
-
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +17,8 @@ var PortsCmd = &cobra.Command{
 		utils.CheckCmdHard("docker-compose")
 
 		docker.HardCheckTokCompose()
+
+		unison.BackgroundServiceWarning(conf.GetConfig().Tokaido.Project.Name)
 
 		docker.PrintPorts(args)
 	},

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/services/docker"
+	"github.com/ironstar-io/tokaido/services/unison"
 	"github.com/ironstar-io/tokaido/utils"
-
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +15,8 @@ var PsCmd = &cobra.Command{
 	Long:  "Alias for running `docker-compose ps`",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.CheckCmdHard("docker-compose")
+
+		unison.BackgroundServiceWarning(conf.GetConfig().Tokaido.Project.Name)
 
 		docker.HardCheckTokCompose()
 

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/ironstar-io/tokaido/conf"
+	"github.com/ironstar-io/tokaido/services/drupal"
+	"github.com/ironstar-io/tokaido/services/unison"
+	"github.com/spf13/cobra"
+)
+
+// PurgeCmd - `tok up`
+var PurgeCmd = &cobra.Command{
+	Use:   "purge",
+	Short: "Purge Varnish and Drupal cache",
+	Long:  "Purge will purge the Varnish cache and run a drush cache-rebuild operation",
+	Run: func(cmd *cobra.Command, args []string) {
+		conf.ValidProjectRoot()
+
+		unison.BackgroundServiceWarning(conf.GetConfig().Tokaido.Project.Name)
+
+		drupal.Purge()
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ func init() {
 	rootCmd.AddCommand(OpenCmd)
 	rootCmd.AddCommand(PortsCmd)
 	rootCmd.AddCommand(PsCmd)
+	rootCmd.AddCommand(PurgeCmd)
 	rootCmd.AddCommand(StatusCmd)
 	rootCmd.AddCommand(StopCmd)
 	rootCmd.AddCommand(SyncCmd)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/services/docker"
 	"github.com/ironstar-io/tokaido/services/drupal"
@@ -8,7 +10,6 @@ import (
 	"github.com/ironstar-io/tokaido/system/console"
 	"github.com/ironstar-io/tokaido/system/ssh"
 	"github.com/ironstar-io/tokaido/utils"
-
 	"github.com/spf13/cobra"
 )
 
@@ -22,18 +23,24 @@ var StatusCmd = &cobra.Command{
 
 		docker.HardCheckTokCompose()
 
-		docker.StatusCheck()
+		err := docker.StatusCheck()
 
-		ssh.CheckKey()
+		err = ssh.CheckKey()
 
-		unison.CheckSyncService(conf.GetConfig().Tokaido.Project.Name)
+		err = unison.CheckSyncService(conf.GetConfig().Tokaido.Project.Name)
 
-		drupal.CheckContainer()
+		err = drupal.CheckContainer()
 
-		console.Println(`
-🍜  Checks have passed successfully
-		`, "")
-		console.Println(`🌎  Run 'tok open' to open the environment in your default browser
-		`, "")
+		if err == nil {
+			fmt.Println()
+			console.Println(`🍜  Checks have passed successfully`, "")
+			fmt.Println()
+			console.Println(`🌎  Run 'tok open' to open the environment in your default browser`, "")
+			fmt.Println()
+		} else {
+			fmt.Println()
+			console.Println("🙅  Some checks failed! Have you tried re-running `tok up`?", "")
+			fmt.Println()
+		}
 	},
 }

--- a/services/docker/compose.go
+++ b/services/docker/compose.go
@@ -1,15 +1,15 @@
 package docker
 
 import (
+	"bufio"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/system/console"
 	"github.com/ironstar-io/tokaido/utils"
-
-	"bufio"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 // ComposeStdout - Convenience method for docker-compose shell commands
@@ -87,7 +87,7 @@ func Exec(args []string) {
 }
 
 // StatusCheck ...
-func StatusCheck() {
+func StatusCheck() error {
 	rawStatus := ComposeResult("ps")
 
 	unavailableContainers := false
@@ -113,9 +113,12 @@ View the status of your containers with 'tok ps'
 
 You can try to fix this by running 'tok up', or by running 'tok repair'.
 	`)
-		os.Exit(1)
+
+		return errors.New("Tokaido containers are not running correctly")
 	}
 
-	console.Println(`
-✅  All containers are running`, "√")
+	fmt.Println()
+	console.Println(`✅  All containers are running`, "√")
+
+	return nil
 }

--- a/services/docker/general.go
+++ b/services/docker/general.go
@@ -22,6 +22,7 @@ var defaultContainers = map[string]string{
 	"mysql":   "3306",
 	"nginx":   "8082",
 	"unison":  "5000",
+	"varnish": "8081",
 }
 
 var optionalContainers = map[string]string{

--- a/services/docker/templates/compose.go
+++ b/services/docker/templates/compose.go
@@ -158,6 +158,8 @@ services:
   varnish:
     user: "1004"
     image: tokaido/varnish:latest
+    ports:
+      - "8081"
     depends_on:
       - nginx
     volumes_from:

--- a/services/drupal/check.go
+++ b/services/drupal/check.go
@@ -1,12 +1,8 @@
 package drupal
 
 import (
-	"github.com/ironstar-io/tokaido/conf"
-	"github.com/ironstar-io/tokaido/services/docker"
-	"github.com/ironstar-io/tokaido/system/console"
-	"github.com/ironstar-io/tokaido/utils"
-
 	"bufio"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -14,6 +10,10 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
+	"github.com/ironstar-io/tokaido/conf"
+	"github.com/ironstar-io/tokaido/services/docker"
+	"github.com/ironstar-io/tokaido/system/console"
+	"github.com/ironstar-io/tokaido/utils"
 )
 
 var rgx = regexp.MustCompile("'(.*?)'")
@@ -34,13 +34,13 @@ func CheckLocal() {
 }
 
 // CheckContainer ...
-func CheckContainer() {
+func CheckContainer() error {
 	haproxyPort := docker.LocalPort("haproxy", "8443")
 
 	drupalStatus := utils.BashStringCmd(`curl -sko /dev/null -I -w"%{http_code}" https://localhost:` + haproxyPort + ` | grep 200`)
 	if drupalStatus == "200" {
 		console.Println("✅  Drupal is listening on HTTPS", "√")
-		return
+		return nil
 	}
 
 	console.Println(`😓  A Drupal site is not installed or is not working
@@ -48,8 +48,8 @@ func CheckContainer() {
 	fmt.Println(`
 Tokaido is running but it looks like your Drupal site isn't installed.
 
-You can install Drupal by using the web interface at 
-https://` + conf.GetConfig().Tokaido.Project.Name + `.local.tokaido.io:5154. 
+You can install Drupal by using the web interface at
+https://` + conf.GetConfig().Tokaido.Project.Name + `.local.tokaido.io:5154.
 
 Note that your database credentials are:
 
@@ -58,10 +58,11 @@ Username: tokaido
 Password: tokaido
 Database name: tokaido
 
-It might be easier to use Drush to install your site, which you can do by 
-connecting to SSH with 'ssh ` + conf.GetConfig().Tokaido.Project.Name + `.tok' and 
+It might be easier to use Drush to install your site, which you can do by
+connecting to SSH with 'ssh ` + conf.GetConfig().Tokaido.Project.Name + `.tok' and
 running 'drush site-install'`)
-	os.Exit(1)
+
+	return errors.New("Drupal site is not installed")
 }
 
 // checkDrupalVersion ...

--- a/services/drupal/purge.go
+++ b/services/drupal/purge.go
@@ -1,0 +1,45 @@
+package drupal
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/ironstar-io/tokaido/services/docker"
+	"github.com/ironstar-io/tokaido/system/ssh"
+)
+
+// Purge will empty the Varnish cache and run a drush cache-rebuild
+func Purge() {
+	purgeVarnish()
+	purgeDrush()
+}
+
+func purgeVarnish() {
+	port := docker.LocalPort("varnish", "8081")
+	client := &http.Client{}
+
+	req, err := http.NewRequest("GET", "http://localhost:"+port, nil)
+	if err != nil {
+		log.Fatalf("Error when opening HTTP client for Varnish purge: %v", err)
+	}
+
+	req.Header.Add("X-PURGEALL", "")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("Error while trying to send Varnish purge request: %v", err)
+	}
+
+	if resp.StatusCode == 200 {
+		fmt.Println("Successfully purged Varnish cache")
+	} else {
+		log.Fatalf("Sorry, Varnish purge failed. Response: %s", resp.Status)
+	}
+}
+
+func purgeDrush() {
+	cmd := []string{"drush cache-rebuild -y"}
+	fmt.Println("Sending drush cache-rebuild request...")
+	resp := ssh.ConnectCommand(cmd)
+	fmt.Println(resp)
+}

--- a/services/unison/goos/sync_darwin.go
+++ b/services/unison/goos/sync_darwin.go
@@ -4,6 +4,7 @@ package goos
 
 import (
 	"bytes"
+	"errors"
 	"log"
 	"os/user"
 	"path/filepath"
@@ -109,16 +110,17 @@ func (s UnisonSvc) SyncServiceStatus() string {
 }
 
 // CheckSyncService a verbose sync status check used for tok status
-func (s UnisonSvc) CheckSyncService() {
+func (s UnisonSvc) CheckSyncService() error {
 	if conf.GetConfig().System.Syncsvc.Enabled != true {
-		return
+		return nil
 	}
 
 	c := s.SyncServiceStatus()
 	if c == "running" {
 		console.Println("✅  Background sync service is running", "√")
-		return
+		return nil
 	}
 
 	console.Println(bgSyncFailMsg, "")
+	return errors.New(bgSyncFailMsg)
 }

--- a/services/unison/goos/sync_linux.go
+++ b/services/unison/goos/sync_linux.go
@@ -3,19 +3,19 @@
 package goos
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
+	"html/template"
+	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/services/unison/templates"
 	"github.com/ironstar-io/tokaido/system/console"
 	"github.com/ironstar-io/tokaido/system/daemon"
 	"github.com/ironstar-io/tokaido/system/fs"
-
-	"bytes"
-	"fmt"
-	"html/template"
-	"log"
-	"path/filepath"
 )
 
 var bgSyncFailMsg = `
@@ -114,16 +114,17 @@ func (s UnisonSvc) StopSyncService() {
 }
 
 // CheckSyncService a verbose sync status check used for tok status
-func (s UnisonSvc) CheckSyncService() {
+func (s UnisonSvc) CheckSyncService() error {
 	if conf.GetConfig().System.Syncsvc.Enabled != true {
-		return
+		return nil
 	}
 
 	c := s.SyncServiceStatus()
 	if c == "running" {
 		console.Println("✅  Background sync service is running", "√")
-		return
+		return nil
 	}
 
 	fmt.Println(bgSyncFailMsg)
+	return errors.New(bgSyncFailMsg)
 }

--- a/services/unison/goos/sync_windows.go
+++ b/services/unison/goos/sync_windows.go
@@ -45,5 +45,5 @@ func (s UnisonSvc) StopSyncService() {
 
 // CheckSyncService - Unused placeholder
 func (s UnisonSvc) CheckSyncService() error {
-	return
+	return nil
 }

--- a/services/unison/goos/sync_windows.go
+++ b/services/unison/goos/sync_windows.go
@@ -2,8 +2,6 @@
 
 package goos
 
-import ()
-
 type UnisonSvc struct {
 	SyncName string
 	SyncDir  string
@@ -46,6 +44,6 @@ func (s UnisonSvc) StopSyncService() {
 }
 
 // CheckSyncService - Unused placeholder
-func (s UnisonSvc) CheckSyncService() {
+func (s UnisonSvc) CheckSyncService() error {
 	return
 }

--- a/services/unison/service.go
+++ b/services/unison/service.go
@@ -1,8 +1,11 @@
 package unison
 
 import (
+	"fmt"
+
 	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/services/unison/goos"
+	"github.com/ironstar-io/tokaido/system/console"
 )
 
 var bgSyncFailMsg = `
@@ -38,4 +41,18 @@ func SyncServiceStatus(syncName string) string {
 func CheckSyncService(syncName string) {
 	s := goos.NewUnisonSvc(syncName, "")
 	s.CheckSyncService()
+}
+
+// BackgroundServiceWarning - Check if the background sync service is running and warn if not
+func BackgroundServiceWarning(syncName string) {
+	if conf.GetConfig().System.Syncsvc.Enabled != true {
+		return
+	}
+
+	s := goos.NewUnisonSvc(syncName, "")
+	if s.SyncServiceStatus() != "running" {
+		fmt.Println()
+		console.Println("⚠️  The background sync service is not running. Manually sync with `tok watch` or try running `tok up` again", "")
+		fmt.Println()
+	}
 }

--- a/services/unison/service.go
+++ b/services/unison/service.go
@@ -38,9 +38,9 @@ func SyncServiceStatus(syncName string) string {
 }
 
 // CheckSyncService a verbose sync status check used for tok status
-func CheckSyncService(syncName string) {
+func CheckSyncService(syncName string) error {
 	s := goos.NewUnisonSvc(syncName, "")
-	s.CheckSyncService()
+	return s.CheckSyncService()
 }
 
 // BackgroundServiceWarning - Check if the background sync service is running and warn if not

--- a/system/opensite.go
+++ b/system/opensite.go
@@ -14,6 +14,7 @@ func OpenSite(args []string) {
 		"adminer": "8080",
 		"mailhog": "8025",
 		"nginx":   "8082",
+		"varnish": "8081",
 	}
 
 	if len(args) >= 1 {
@@ -21,7 +22,7 @@ func OpenSite(args []string) {
 			if len(services[arg]) > 0 {
 				p = docker.LocalPort(arg, services[arg])
 				if arg == "haproxy" {
-					OpenHaproxySite()
+					goos.OpenSite("https://localhost:" + p)
 					return
 				}
 				goos.OpenSite("http://localhost:" + p)

--- a/system/ssh/keys.go
+++ b/system/ssh/keys.go
@@ -1,22 +1,22 @@
 package ssh
 
 import (
-	"github.com/ironstar-io/tokaido/conf"
-	"github.com/ironstar-io/tokaido/services/docker"
-	"github.com/ironstar-io/tokaido/system/console"
-	"github.com/ironstar-io/tokaido/system/fs"
-	"github.com/ironstar-io/tokaido/utils"
-
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 
+	"github.com/ironstar-io/tokaido/conf"
+	"github.com/ironstar-io/tokaido/services/docker"
+	"github.com/ironstar-io/tokaido/system/console"
+	"github.com/ironstar-io/tokaido/system/fs"
+	"github.com/ironstar-io/tokaido/utils"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -24,14 +24,14 @@ var sshPriv = filepath.Join(fs.HomeDir(), "/.ssh/tok_ssh.key")
 var sshPub = filepath.Join(fs.HomeDir(), "/.ssh/tok_ssh.pub")
 
 // CheckKey ...
-func CheckKey() {
+func CheckKey() error {
 	localPort := docker.LocalPort("drush", "22")
 	cmdStr := `ssh ` + conf.GetConfig().Tokaido.Project.Name + `.tok -q -p ` + localPort + ` -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -C "echo 1" | echo $?`
 
 	keyResult := utils.BashStringCmd(cmdStr)
 	if keyResult == "0" {
 		console.Println("✅  SSH access is configured", "√")
-		return
+		return nil
 	}
 
 	console.Println(`😓  SSH access not configured
@@ -41,7 +41,8 @@ Make sure you have an SSH public key uploaded in './.tok/local/ssh_key.pub'.
 
 You should be able to run 'tok repair' to attempt to fix this automatically
 	`, "×")
-	os.Exit(1)
+
+	return errors.New("SSH access is not configured")
 }
 
 // GenerateKeys ...


### PR DESCRIPTION
This feature adds the command `tok purge` which will purge the varnish cache and also run drush cache-rebuild. 

It updates the Varnish configuration to expose Varnish' port to the local host, and also updates `tok open` to support opening Varnish. 

Finally it adds a small tweak to `tok open haproxy` so that the haproxy local port is opened, rather than just opening the tokaido proxy port which is a bit redundant, since `tok open` just does this already. 