### PR TITLE
Add support for specifying drupal profile during install

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var profileFlag string
+
 // NewCmd - `tok new {project}`
 var NewCmd = &cobra.Command{
 	Use:   "new",
@@ -14,6 +16,6 @@ var NewCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.CheckCmdHard("docker-compose")
 
-		tok.New(args)
+		tok.New(args, profileFlag)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,8 @@ func RootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug mode, command output is printed to the console")
 
 	OpenCmd.PersistentFlags().BoolVarP(&adminFlag, "admin", "", false, "Create a one-time admin login URL and open")
+	
+	NewCmd.PersistentFlags().StringVarP(&profileFlag, "profile", "p", "", "Specify the Drupal install profile. Supported values are 'standard', 'minimal', and 'demo_umami")
 
 	return &rootCmd
 }

--- a/services/tok/new.go
+++ b/services/tok/new.go
@@ -23,6 +23,8 @@ import (
 	"github.com/ironstar-io/tokaido/system/version"
 )
 
+var profileFlag string
+
 func buildProjectFrame(projectName string) {
 	if fs.CheckExists(projectName) == true {
 		log.Fatal("The project '" + projectName + "' already exists in this directory. Exiting...")
@@ -51,9 +53,20 @@ func setupProxy() {
 		proxy.Setup()
 	}
 }
-func drushSiteInstall() {
-	ssh.StreamConnectCommand([]string{"drush", "site-install", "-y"})
-	ssh.StreamConnectCommand([]string{"drush", "en", "swiftmailer", "password_policy", "password_policy_character_types", "password_policy_characters", "password_policy_username", "memcache", "health_check"})
+func drushSiteInstall(profile string) {
+	switch profile {
+		case "": 
+			profile = "standard"
+			fallthrough		
+		case
+			"standard",
+			"minimal",
+			"demo_umami":
+			ssh.StreamConnectCommand([]string{"drush", "site-install", profile, "-y"})
+			ssh.StreamConnectCommand([]string{"drush", "en", "swiftmailer", "password_policy", "password_policy_character_types", "password_policy_characters", "password_policy_username", "memcache", "health_check"})		
+			return
+		}
+		log.Fatalf("Error: The install profile specified was not supported. Possible values are 'standard', 'minimal', and 'umami'")
 }
 
 func deduceProjectName(args []string) string {
@@ -65,7 +78,7 @@ func deduceProjectName(args []string) string {
 }
 
 // New - The core run sheet of `tok new {project}`
-func New(args []string) {
+func New(args []string, profile string) {	
 	// Project frame
 	pn := deduceProjectName(args)
 	buildProjectFrame(pn)
@@ -124,7 +137,7 @@ func New(args []string) {
 
 	// Drush site install, add additional packages
 	console.Println(`💧  Running drush site-install for your new project`, "")
-	drushSiteInstall()
+	drushSiteInstall(profile)
 
 	// Generate a new .gitignore file
 	git.NewGitignore()


### PR DESCRIPTION
Allows users to specify `--profile [demo_umami, minimal, standard]` when running `tok new`

Will default to `standard`