### PR TITLE
Remove volume delete from tok destroy

### DIFF
--- a/services/tok/destroy.go
+++ b/services/tok/destroy.go
@@ -1,7 +1,6 @@
 package tok
 
 import (
-	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/services/docker"
 	"github.com/ironstar-io/tokaido/services/proxy"
 	"github.com/ironstar-io/tokaido/system/console"
@@ -23,9 +22,6 @@ func Destroy() {
 	fmt.Println()
 
 	docker.Down()
-	docker.DeleteVolume("tok_" + conf.GetConfig().Tokaido.Project.Name + "_tokaido_site")
-
-	// unison.UnloadSyncService(conf.GetConfig().Tokaido.Project.Name)
 
 	proxy.DockerComposeUp()
 }


### PR DESCRIPTION
The `tok destroy` command tries to remove unused docker volumes but this command runs into errors more often than not because of issues within Docker. This PR removes that command and will stop users from being confused when encountering this problem. 