### PR TITLE
Updated 'new' functionality

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -172,14 +172,6 @@
   revision = "0dae4fefe7c0e190f7b5a78dac28a1c82cc8d849"
 
 [[projects]]
-  digest = "1:213ecd7cf2442d4c3fb297fdcb00c70be7aaed543b78c8b77a0ed5622940a6f1"
-  name = "github.com/judwhite/go-svc"
-  packages = ["svc"]
-  pruneopts = "UT"
-  revision = "63c12402f579f0bdf022653c821a1aa5d7544f01"
-  version = "v1.0.0"
-
-[[projects]]
   branch = "master"
   digest = "1:e51f40f0c19b39c1825eadd07d5c0a98a2ad5942b166d9fc4f54750ce9a04810"
   name = "github.com/juju/ansiterm"
@@ -224,6 +216,14 @@
   ]
   pruneopts = "UT"
   revision = "90697d60dd844d5ef6ff15135d0203f65d2f53b8"
+
+[[projects]]
+  digest = "1:ba852707958e39694e7f64328008287892adf9b1aed0174480e2f50e0c23e521"
+  name = "github.com/logrusorgru/aurora"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "21d75270181e0436fee7bd58b991c212cf309068"
+  version = "v2.0"
 
 [[projects]]
   branch = "master"
@@ -386,6 +386,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:4a0ab26712dc866a15584f83a6004f447e692f69fdbcdfc61ea2f32836bd7065"
+  name = "github.com/ryanuber/columnize"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9e6335e58db3b4cfe3c3c5c881f51ffbc1091b34"
+  version = "v2.1.1"
+
+[[projects]]
   digest = "1:3265b6b251e076aa31b46c3b58cf55670818be301024d29bc5de35f1ca9790c7"
   name = "github.com/sanity-io/litter"
   packages = ["."]
@@ -489,12 +497,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f0542fa14fd5819a2f09b5bdb3f5225cf3598c726f633ef92492d62621d85557"
+  digest = "1:105645ed366a17f9ed1007059f0d3506e73e2098f2a1e793ffa92917d6461060"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
-    "windows/svc",
   ]
   pruneopts = "UT"
   revision = "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b"
@@ -564,16 +571,17 @@
     "github.com/google/certificate-transparency-go/x509",
     "github.com/jmhodges/clock",
     "github.com/jmoiron/sqlx",
-    "github.com/judwhite/go-svc/svc",
     "github.com/kisielk/sqlstruct",
     "github.com/kisom/goutils/assert",
     "github.com/lib/pq",
+    "github.com/logrusorgru/aurora",
     "github.com/manifoldco/promptui",
     "github.com/mattn/go-sqlite3",
     "github.com/mitchellh/go-homedir",
     "github.com/olekukonko/tablewriter",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
+    "github.com/ryanuber/columnize",
     "github.com/sanity-io/litter",
     "github.com/spf13/cobra",
     "github.com/spf13/viper",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,6 +8,10 @@
   unused-packages = true
 
 [[constraint]]
+  name = "github.com/logrusorgru/aurora"
+  version = "v2.0"
+
+[[constraint]]
   name = "github.com/onsi/ginkgo"
   version = "1.5.0"
 

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -6,16 +6,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var profileFlag string
+var templateFlag string
 
 // NewCmd - `tok new {project}`
 var NewCmd = &cobra.Command{
-	Use:   "new",
+	Use:   "new [project-name]",
 	Short: "Create a new Drupal 8 project",
-	Long:  "Creates a new Drupal project with `tok new {project-name}`, initialises git, installs Drupal and dependencies, installs Tokaido on the new site",
+	Long: `The fastest way to launch new Drupal projects
+using open source templates by Tokaido and the community.
+Complete documentation is available at https://docs.tokaido.io/tokaido/starting-a-new-drupal-project`,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.CheckCmdHard("docker-compose")
 
-		tok.New(args, profileFlag)
+		tok.New(args, templateFlag)
 	},
 }

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -22,7 +22,7 @@ var RebuildCmd = &cobra.Command{
 		docker.Stop()
 		unison.UnloadSyncService(conf.GetConfig().Tokaido.Project.Name)
 
-		tok.Init()
+		tok.Init(true, false)
 
 		tok.InitMessage()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,9 +67,9 @@ func RootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug mode, command output is printed to the console")
 
 	OpenCmd.PersistentFlags().BoolVarP(&adminFlag, "admin", "", false, "Create a one-time admin login URL and open")
-
-	NewCmd.PersistentFlags().StringVarP(&profileFlag, "profile", "p", "", "Specify the Drupal install profile. Supported values are 'standard', 'minimal', and 'demo_umami")
 	SnapshotNewCmd.PersistentFlags().StringVarP(&nameFlag, "name", "n", "", "Specify a name to be added to the snapshot name. If not specified, Tokaido will only use the current UTC date and time")
+
+	NewCmd.PersistentFlags().StringVarP(&templateFlag, "template", "t", "", "Specify a template to use such as drupal8-standard. See templates at: https://github.com/ironstar-io/tokaido-drupal-package-builder")
 
 	return &rootCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,7 +63,8 @@ func Execute() {
 // RootCmd will setup and return the root command
 func RootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().StringP("config", "c", "", "Specify the Tokaido config file to use")
-	rootCmd.PersistentFlags().BoolP("force", "", false, "Forcefully skip confirmation prompts with 'yes' response")
+	rootCmd.PersistentFlags().BoolP("force", "", false, "Forcefully skip destructive confirmation prompts")
+	rootCmd.PersistentFlags().BoolP("yes", "y", false, "Auto-accept any non-destructive confirmation prompts")
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug mode, command output is printed to the console")
 
 	OpenCmd.PersistentFlags().BoolVarP(&adminFlag, "admin", "", false, "Create a one-time admin login URL and open")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -18,7 +18,7 @@ var UpCmd = &cobra.Command{
 		utils.CheckCmdHard("docker-compose")
 		conf.ValidProjectRoot()
 
-		tok.Init()
+		tok.Init(conf.GetConfig().Tokaido.Yes, true)
 		tok.InitMessage()
 	},
 }

--- a/conf/replace.go
+++ b/conf/replace.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -28,9 +29,11 @@ func commandSubstitution(name string, args ...string) {
 func CreateOrReplaceDrupalConfig(path, version string) {
 	viper.Set("drupal.path", path)
 	viper.Set("drupal.majorversion", version)
-	cf := viper.ConfigFileUsed()
 
-	if cf == "" {
-		fs.TouchByteArray(filepath.Join(GetConfig().Tokaido.Project.Path, "/.tok/config.yml"), drupalVars(path, version))
+	configPath := filepath.Join(GetConfig().Tokaido.Project.Path, "/.tok/config.yml")
+
+	_, err := os.Stat(configPath)
+	if os.IsNotExist(err) {
+		fs.TouchByteArray(configPath, drupalVars(path, version))
 	}
 }

--- a/conf/set_config.go
+++ b/conf/set_config.go
@@ -41,6 +41,7 @@ func SetConfigValueByArgs(args []string) {
 	// Stop these values leaking into config
 	c.Tokaido.Debug = false
 	c.Tokaido.Force = false
+	c.Tokaido.Yes = false
 	c.Tokaido.Project.Path = ""
 	c.System.Syncsvc.Launchdpath = ""
 	c.System.Syncsvc.Systemdpath = ""

--- a/conf/struct.go
+++ b/conf/struct.go
@@ -18,6 +18,7 @@ type Config struct {
 		Dependencychecks bool   `yaml:"dependencychecks"`
 		Enableemoji      bool   `yaml:"enableemoji"`
 		Force            bool   `yaml:"force,omitempty"`
+		Yes              bool   `yaml:"yes,omitempty"`
 		Phpversion       string `yaml:"phpversion"`
 		Stability        string `yaml:"stability"`
 		Xdebug           bool   `yaml:"xdebug"`

--- a/initialize/main.go
+++ b/initialize/main.go
@@ -68,6 +68,7 @@ func readProjectConfig(command string) {
 	viper.SetDefault("Tokaido.Customcompose", viper.GetBool("customCompose"))
 	viper.SetDefault("Tokaido.Debug", viper.GetBool("debug"))
 	viper.SetDefault("Tokaido.Force", viper.GetBool("force"))
+	viper.SetDefault("Tokaido.Yes", viper.GetBool("yes"))
 	viper.SetDefault("Tokaido.Stability", "edge")
 	viper.SetDefault("Tokaido.Dependencychecks", true)
 	viper.SetDefault("Tokaido.Enableemoji", emojiDefaults())

--- a/services/tok/init.go
+++ b/services/tok/init.go
@@ -18,8 +18,12 @@ import (
 )
 
 // Init - The core run sheet of `tok up`
-func Init() {
+func Init(yes, statuscheck bool) {
 	c := conf.GetConfig()
+	cs := "ASK"
+	if yes {
+		cs = "FORCE"
+	}
 
 	// System readiness checks
 	version.Check()
@@ -27,7 +31,7 @@ func Init() {
 
 	// Create Tokaido configuration
 	conf.SetDrupalConfig("CUSTOM")
-	drupal.CheckSettings("ASK")
+	drupal.CheckSettings(cs)
 	docker.FindOrCreateTokCompose()
 	ssh.GenerateKeys()
 	docker.CreateDatabaseVolume()
@@ -72,18 +76,20 @@ func Init() {
 		console.Println(`🙂  All containers are running`, "√")
 	}
 
-	err = ssh.CheckKey()
+	if statuscheck {
+		err = ssh.CheckKey()
+		err = drupal.CheckContainer()
 
-	err = drupal.CheckContainer()
-
-	if err == nil {
-		console.Println(`🍜  Tokaido started up successfully`, "")
-	} else {
-		fmt.Println()
-		console.Println("🙅  Uh oh! It looks like Tokaido didn't start properly.", "")
-		console.Println("    Come find us in #tokaido on the Drupal Slack if you need some help", "")
-		fmt.Println()
+		if err == nil {
+			console.Println(`🍜  Tokaido started up successfully`, "")
+		} else {
+			fmt.Println()
+			console.Println("🙅  Uh oh! It looks like Tokaido didn't start properly.", "")
+			console.Println("    Come find us in #tokaido on the Drupal Slack if you need some help", "")
+			fmt.Println()
+		}
 	}
+
 }
 
 // InitMessage ...

--- a/services/tok/new.go
+++ b/services/tok/new.go
@@ -1,27 +1,43 @@
 package tok
 
 import (
+	"bufio"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/constants"
 	"github.com/ironstar-io/tokaido/initialize"
-	"github.com/ironstar-io/tokaido/services/docker"
-	"github.com/ironstar-io/tokaido/services/drupal"
-	"github.com/ironstar-io/tokaido/services/drush"
 	"github.com/ironstar-io/tokaido/services/git"
 	"github.com/ironstar-io/tokaido/services/proxy"
 	"github.com/ironstar-io/tokaido/services/tok/goos"
-	"github.com/ironstar-io/tokaido/services/xdebug"
-	"github.com/ironstar-io/tokaido/system"
 	"github.com/ironstar-io/tokaido/system/console"
 	"github.com/ironstar-io/tokaido/system/fs"
 	"github.com/ironstar-io/tokaido/system/ssh"
 	"github.com/ironstar-io/tokaido/utils"
+	"github.com/manifoldco/promptui"
+	yaml "gopkg.in/yaml.v2"
 )
+
+// Templates is a list of drupal templates available for download
+type Templates struct {
+	Template []Template `yaml:"templates"`
+}
+
+// Template ...
+type Template struct {
+	Description    string   `yaml:"description"`
+	DrupalVersion  int      `yaml:"drupal_version"`
+	Maintainer     string   `yaml:"maintainer"`
+	Name           string   `yaml:"name"`
+	PackageURL     string   `yaml:"package_url"`
+	PostUpCommands []string `yaml:"post_up_commands,omitempty"`
+}
 
 var profileFlag string
 
@@ -77,94 +93,218 @@ func deduceProjectName(args []string) string {
 	return args[0]
 }
 
+func resolveProjectName(args []string) (name string) {
+	if len(args) == 1 {
+		name = args[0]
+	} else if len(args) < 1 {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Println("")
+		fmt.Printf("Enter a directory name for your new project: ")
+		name, _ = reader.ReadString('\n')
+	} else {
+		fmt.Println("ERROR: Received too many arguments. New project name must be a one word string.")
+		os.Exit(1)
+	}
+
+	// Rationalise the name to strip out any problematic characters
+	reg, err := regexp.Compile("[^a-zA-Z0-9\\-]+")
+	if err != nil {
+		log.Fatal(err)
+	}
+	name = reg.ReplaceAllString(name, "")
+
+	return name
+}
+
+func marshalTemplates() Templates {
+	req, err := http.NewRequest(http.MethodGet, "https://downloads.tokaido.io/templates.yaml", nil)
+	if err != nil {
+		log.Fatalf("Error while trying to retrieve list of available templates: %v", err)
+	}
+
+	client := http.Client{
+		Timeout: time.Second * 3,
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("Error while trying to retrieve list of available templates: %v", err)
+	}
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		log.Fatalf("Error while trying to read list of available templates: %v", err)
+	}
+
+	templates := Templates{}
+	err = yaml.Unmarshal(body, &templates)
+	if err != nil {
+		log.Fatalf("Error while trying to unmarshal list of available templates: %v", err)
+	}
+
+	return templates
+}
+
+func chooseTemplate(tp *Templates) (template Template) {
+	var templates []Template
+	size := 0
+
+	// Convert our templates struct into a more useable format
+	for _, t := range tp.Template {
+		size = size + 1
+		templates = append(templates, t)
+	}
+
+	// Define the menu's visual template
+	menuTemplate := &promptui.SelectTemplates{
+		Label:    "{{ . }}?",
+		Active:   `🤔 {{ .Name | cyan }}`,
+		Inactive: `   {{ .Name | cyan }}`,
+		Selected: "{{ .Name | blue | cyan }}",
+		Details: `---------
+{{ .Description | faint  }}
+
+Maintainer: {{ .Maintainer | faint }}
+PackageURL: {{ .PackageURL | faint }}
+`,
+	}
+
+	fmt.Println("Please choose the Drupal template you'd like to launch")
+
+	prompt := promptui.Select{
+		Label:     "Templates >>",
+		Items:     templates,
+		Templates: menuTemplate,
+		Size:      size,
+	}
+
+	i, _, err := prompt.Run()
+
+	if err != nil {
+		log.Fatalf("Prompt failed %v\n", err)
+
+	}
+
+	return templates[i]
+}
+
+func resolveTemplateName(requestTemplate string) (template Template) {
+	// Get a list of available templates
+	templates := marshalTemplates()
+
+	// If the user didn't specify a template name, give them a list to choose from
+	if requestTemplate == "" {
+		template = chooseTemplate(&templates)
+		return template
+	}
+
+	// If the user did specify a template name, see if that template is available
+	for _, t := range templates.Template {
+		if requestTemplate == t.Name {
+			utils.DebugString("[new] found matching template: [" + t.Name + "] at [" + t.PackageURL + "]")
+			return t
+		}
+	}
+
+	fmt.Println("found no template")
+	return
+}
+
 // New - The core run sheet of `tok new {project}`
-func New(args []string, profile string) {
-	// Project frame
-	pn := deduceProjectName(args)
-	buildProjectFrame(pn)
+func New(args []string, requestTemplate string) {
 
-	console.Println("\n🍚  Creating a brand new Drupal 8 site with Tokaido!", "")
+	// Determine the name of the new project
+	name := resolveProjectName(args)
 
-	// Create Tokaido configuration
-	conf.SetDrupalConfig("DEFAULT")
-	docker.FindOrCreateTokCompose()
-	docker.CreateDatabaseVolume()
-	docker.CreateSiteVolume()
-	docker.CreateComposerCacheVolume()
-	ssh.GenerateKeys()
+	// Determine the template to be used to launch this project
+	template := resolveTemplateName(requestTemplate)
 
-	// Initial directory sync
-	siteVolName := "tok_" + conf.GetConfig().Tokaido.Project.Name + "_tokaido_site"
-	wo := console.SpinStart("Performing an initial sync...")
-	utils.StdoutStreamCmdDebug("docker", "run", "-e", "AUTO_SYNC=false", "-v", conf.GetConfig().Tokaido.Project.Path+":/tokaido/host-volume", "-v", siteVolName+":/tokaido/site", "tokaido/sync:stable")
-	console.SpinPersist(wo, "🚛", "Initial sync completed")
+	fmt.Printf("Launching new project [%s] with Drupal template [%s]", name, template.Name)
 
-	// Lift drush container and configure
-	drush.DockerUp()
-	drupal.ConfigureSSH()
-	xdebug.Configure()
+	// pn := deduceProjectName(args)
+	// buildProjectFrame(pn)
 
-	// Lift background sync container
-	docker.UpMulti([]string{"sync"})
+	// console.Println("\n🍚  Creating a brand new Drupal 8 site with Tokaido!", "")
 
-	console.Println("🎼  Using composer to generate the new Drupal project files. This might take some time", "")
-	// `composer create-project` inside the drush container
-	composerCreateProject()
-	// Pull all required docker images
-	docker.PullImages()
+	// // Create Tokaido configuration
+	// conf.SetDrupalConfig("DEFAULT")
+	// docker.FindOrCreateTokCompose()
+	// docker.CreateDatabaseVolume()
+	// docker.CreateSiteVolume()
+	// docker.CreateComposerCacheVolume()
+	// ssh.GenerateKeys()
 
-	wo = console.SpinStart("Waiting for sync to complete. This might take a few minutes...")
-	filepath := drupal.SettingsPath()
-	err := fs.WaitForSync(filepath, 180)
-	if err != nil {
-		console.Println("\n🙅‍  Your new Drupal site failed to sync from the Tokaido environment to your local disk", "")
-		panic(err)
-	}
-	console.SpinPersist(wo, "🚋", "Secondary sync completed successfully")
+	// // Initial directory sync
+	// siteVolName := "tok_" + conf.GetConfig().Tokaido.Project.Name + "_tokaido_site"
+	// wo := console.SpinStart("Performing an initial sync...")
+	// utils.StdoutStreamCmdDebug("docker", "run", "-e", "AUTO_SYNC=false", "-v", conf.GetConfig().Tokaido.Project.Path+":/tokaido/host-volume", "-v", siteVolName+":/tokaido/site", "tokaido/sync:stable")
+	// console.SpinPersist(wo, "🚛", "Initial sync completed")
 
-	// Fire up the full Tokaido environment
-	fmt.Println()
-	wo = console.SpinStart("Tokaido is starting your containers")
-	docker.Up()
-	console.SpinPersist(wo, "🚅", "Tokaido started your containers")
+	// // Lift drush container and configure
+	// drush.DockerUp()
+	// drupal.ConfigureSSH()
+	// xdebug.Configure()
 
-	// Create Tokaido configuration for drupal post composer install
-	drupal.CheckSettings("FORCE")
+	// // Lift background sync container
+	// docker.UpMulti([]string{"sync"})
 
-	// Setup HTTPS proxy service. Retain if statement to preserve Tokaido level enable/disable defaults
-	setupProxy()
+	// console.Println("🎼  Using composer to generate the new Drupal project files. This might take some time", "")
+	// // `composer create-project` inside the drush container
+	// composerCreateProject()
+	// // Pull all required docker images
+	// docker.PullImages()
 
-	wo = console.SpinStart("Waiting for settings.tok.php to sync. This might take a few minutes...")
-	filepath = drupal.SettingsTokPath()
-	err = fs.WaitForSync(filepath, 120)
-	if err != nil {
-		console.Println("\n🙅‍  Your new Drupal site failed to sync from the Tokaido environment to your local disk", "")
-		panic(err)
-	}
+	// wo = console.SpinStart("Waiting for sync to complete. This might take a few minutes...")
+	// filepath := drupal.SettingsPath()
+	// err := fs.WaitForSync(filepath, 180)
+	// if err != nil {
+	// 	console.Println("\n🙅‍  Your new Drupal site failed to sync from the Tokaido environment to your local disk", "")
+	// 	panic(err)
+	// }
+	// console.SpinPersist(wo, "🚋", "Secondary sync completed successfully")
 
-	// Induce a final wait for the sync process to complete
-	time.Sleep(120 * time.Second)
+	// // Fire up the full Tokaido environment
+	// fmt.Println()
+	// wo = console.SpinStart("Tokaido is starting your containers")
+	// docker.Up()
+	// console.SpinPersist(wo, "🚅", "Tokaido started your containers")
 
-	console.SpinPersist(wo, "🚋", "Final sync completed successfully")
+	// // Create Tokaido configuration for drupal post composer install
+	// drupal.CheckSettings("FORCE")
 
-	// Drush site install, add additional packages
-	console.Println(`💧  Running drush site-install for your new project`, "")
-	drushSiteInstall(profile)
+	// // Setup HTTPS proxy service. Retain if statement to preserve Tokaido level enable/disable defaults
+	// setupProxy()
 
-	// Generate a new .gitignore file
-	git.NewGitignore()
-	// Git stage all applicable files and commit
-	git.AddAll()
-	git.Commit("Initial Tokaido Configuration")
+	// wo = console.SpinStart("Waiting for settings.tok.php to sync. This might take a few minutes...")
+	// filepath = drupal.SettingsTokPath()
+	// err = fs.WaitForSync(filepath, 120)
+	// if err != nil {
+	// 	console.Println("\n🙅‍  Your new Drupal site failed to sync from the Tokaido environment to your local disk", "")
+	// 	panic(err)
+	// }
 
-	// TODO: `tok status`
-	// TODO: `tok test`
+	// // Induce a final wait for the sync process to complete
+	// time.Sleep(120 * time.Second)
 
-	// Provide the user a success message
-	goos.InitMessage()
+	// console.SpinPersist(wo, "🚋", "Final sync completed successfully")
 
-	// Open the main site at `https://<project-name>.local.tokaido.io:5154`
-	system.OpenTokaidoProxy(false)
+	// // Drush site install, add additional packages
+	// console.Println(`💧  Running drush site-install for your new project`, "")
+	// drushSiteInstall(profile)
+
+	// // Generate a new .gitignore file
+	// git.NewGitignore()
+	// // Git stage all applicable files and commit
+	// git.AddAll()
+	// git.Commit("Initial Tokaido Configuration")
+
+	// // TODO: `tok status`
+	// // TODO: `tok test`
+
+	// // Provide the user a success message
+	// goos.InitMessage()
+
+	// // Open the main site at `https://<project-name>.local.tokaido.io:5154`
+	// system.OpenTokaidoProxy(false)
 
 }
 


### PR DESCRIPTION
fixes #138 
implements #128 

This PR updates `tok new` so that it downloads pre-built Drupal packages and unpacks then before starting the local Tokaido environment. 