### PR TITLE
refactor config management code to make room for future updates

### DIFF
--- a/conf/set_config.go
+++ b/conf/set_config.go
@@ -46,7 +46,10 @@ func SetConfigValueByArgs(args []string, configType string) {
 		runningConfig.Global.Projects = nil
 	}
 
-	writeConfig(runningConfig, newConfig, configPath)
+	writeConfig(runningConfig, configPath)
+
+	// validate that our config was saved successfully
+	compareFiles(newConfig, configPath)
 }
 
 // mergeConfigInMemory takes our saved config from disk, the new yaml string, and the running
@@ -74,7 +77,7 @@ func mergeConfigInMemory(newYaml, configPath string, runningConfig *Config) (new
 }
 
 // writeConfig writes the provided in-memory config to the configPath
-func writeConfig(runningConfig *Config, newConfig []byte, configPath string) {
+func writeConfig(runningConfig *Config, configPath string) {
 	// Now that we've merged the config, we'll write that merged config to disk
 	newMarhsalled, err := yaml.Marshal(runningConfig)
 	if err != nil {
@@ -82,8 +85,6 @@ func writeConfig(runningConfig *Config, newConfig []byte, configPath string) {
 	}
 
 	fs.Replace(configPath, newMarhsalled)
-
-	compareFiles(newConfig, configPath)
 }
 
 // RegisterProject adds a project to the global config file
@@ -97,7 +98,7 @@ func RegisterProject(name, path string) {
 		Path: path,
 	}
 
-	fmt.Println("\n\naddinug project: ", project)
+	fmt.Println("\n\nadding project: ", project)
 
 	c.Global.Projects = append(c.Global.Projects, project)
 

--- a/conf/struct.go
+++ b/conf/struct.go
@@ -1,5 +1,11 @@
 package conf
 
+// Project is a singular entry of a project name and path used in global config
+type Project struct {
+	Name string `yaml:"name,omitempty"`
+	Path string `yaml:"path,omitempty"`
+}
+
 // Config the application's configuration
 // IMPORTANT!
 // Casing of the `Config` struct properties is important to note
@@ -9,7 +15,8 @@ package conf
 // and that they are able to be properly parsed by the `tok config-x` commands
 type Config struct {
 	Global struct {
-		Syncservice string `yaml:"syncservice,omitempty"`
+		Syncservice string    `yaml:"syncservice,omitempty"`
+		Projects    []Project `yaml:"projects,omitempty"`
 	} `yaml:"global,omitempty"`
 	Tokaido struct {
 		Config           string `yaml:"config,omitempty"`


### PR DESCRIPTION
- update variable names to remove some obscurity
- many more comments
- break config comparison and merge into separate funcs so that they can be reused later for writing the global config in a separate setConfigByArgs func