### PR TITLE
Check if directory is valid before creating .tok for all relative commands

### DIFF
--- a/cmd/config-get.go
+++ b/cmd/config-get.go
@@ -19,7 +19,6 @@ var ConfigGetCmd = &cobra.Command{
 	Long:  "Get a config property value. Eg. `tok config-get drupal path`. See https://tokaido.io/docs/config for a full list of available options",
 	Run: func(cmd *cobra.Command, args []string) {
 		initialize.TokConfig("config-get")
-		conf.ValidProjectRoot()
 
 		c, err := conf.GetConfigValueByArgs(args)
 		if err != nil {

--- a/cmd/config-set.go
+++ b/cmd/config-set.go
@@ -13,7 +13,6 @@ var ConfigSetCmd = &cobra.Command{
 	Long:  "Set a config property value. Eg. `tok config-set services solr enabled true`. See https://tokaido.io/docs/config for a full list of available options",
 	Run: func(cmd *cobra.Command, args []string) {
 		initialize.TokConfig("config-get")
-		conf.ValidProjectRoot()
 
 		conf.SetConfigValueByArgs(args, "project")
 	},

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,7 +13,6 @@ var ConfigCmd = &cobra.Command{
 	Long:  "An interactive Tokaido config editor",
 	Run: func(cmd *cobra.Command, args []string) {
 		initialize.TokConfig("config")
-		conf.ValidProjectRoot()
 
 		conf.MainMenu()
 	},

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -16,7 +16,6 @@ var UpCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		initialize.TokConfig("up")
 		utils.CheckCmdHard("docker-compose")
-		conf.ValidProjectRoot()
 
 		tok.Init(conf.GetConfig().Tokaido.Yes, true)
 		tok.InitMessage()

--- a/conf/check.go
+++ b/conf/check.go
@@ -4,11 +4,12 @@ import (
 	"log"
 
 	"github.com/ironstar-io/tokaido/constants"
+	"github.com/ironstar-io/tokaido/system/fs"
 )
 
 // ValidProjectRoot - Check if the project root was found, if not log and exit
 func ValidProjectRoot() {
-	if GetConfig().Tokaido.Project.Name == constants.ProjectRootNotFound {
+	if fs.ProjectRoot() == constants.ProjectRootNotFound {
 		log.Fatal(constants.ProjectNotFoundError)
 	}
 }

--- a/initialize/main.go
+++ b/initialize/main.go
@@ -19,6 +19,7 @@ import (
 
 // TokConfig - loads the config from a file if specified, otherwise from the environment
 func TokConfig(command string) {
+	conf.ValidProjectRoot()
 	createDotTok()
 	createGlobalDotTok()
 


### PR DESCRIPTION
Resolves https://github.com/ironstar-io/tokaido/issues/153, which actually was not isolated to the `up` command. Any `tok` command that was checking on `.tok` directory outside a git dir or child was susceptible to this issue. 

Majority of commands have a change in operation, would recommend pulling down and giving a test before merge