### PR TITLE
show docker image download progress

### DIFF
--- a/services/docker/compose.go
+++ b/services/docker/compose.go
@@ -18,6 +18,13 @@ func ComposeStdout(args ...string) {
 	utils.StdoutCmd("docker-compose", composeParams...)
 }
 
+// ComposeStreamStdout - Convenience method for docker-compose shell commands
+func ComposeStreamStdout(args ...string) {
+	composeParams := composeArgs(args...)
+
+	utils.StdoutStreamCmd("docker-compose", composeParams...)
+}
+
 // ComposeResult - Convenience method for docker-compose shell commands returning a result
 func ComposeResult(args ...string) string {
 	composeParams := composeArgs(args...)

--- a/services/docker/image.go
+++ b/services/docker/image.go
@@ -6,7 +6,7 @@ import (
 
 // PullImages - Pull all images in compose file
 func PullImages() {
-	ComposeStdout("pull")
+	ComposeStreamStdout("pull")
 }
 
 // ImageExists - Check if an image exists

--- a/services/tok/init.go
+++ b/services/tok/init.go
@@ -78,15 +78,11 @@ func Init(yes, statuscheck bool) {
 		console.SpinPersist(wo, "🚛", "Initial sync completed")
 	}
 
-	wo := console.SpinStart("Downloading the latest Docker images")
+	fmt.Println("🤖  Downloading the latest Docker images")
 	docker.PullImages()
-	console.SpinPersist(wo, "🤖", "Latest Docker images downloaded successfully")
 
-	// wo = console.SpinStart("Starting your containers")
+	console.Println("🚅  Starting your Drupal environment", "")
 	docker.Up()
-	// console.SpinPersist(wo, "🚅", "Tokaido containers are online")
-
-	console.Println("🚅  Configuring your new Drupal environment", "")
 	surveyMessage()
 	// Perform post-launch configuration
 	drupal.ConfigureSSH()


### PR DESCRIPTION
Implements command streaming for `docker-compose pull` so that users can see the progress of downloading docker images as it happens. 

It makes our beautiful `up` output less pleasing, but it's worth it. 

![image](https://user-images.githubusercontent.com/9390978/58131531-45ba7e80-7c62-11e9-826a-b43dd7035a7c.png)

