### PR TITLE
make xdebug easier to activate and available globally

### DIFF
--- a/cmd/config-set.go
+++ b/cmd/config-set.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/initialize"
 	"github.com/ironstar-io/tokaido/services/telemetry"
+	. "github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +20,14 @@ var ConfigSetCmd = &cobra.Command{
 		conf.ValidProjectRoot()
 		telemetry.SendCommand("config-set")
 
-		conf.SetConfigValueByArgs(args, "project")
+		if args[0] == "global" {
+			err := conf.SetGlobalConfigValueByArgs(args)
+			if err != nil {
+				fmt.Println(Red(err))
+			}
+		} else {
+			conf.SetConfigValueByArgs(args, "project")
+		}
+
 	},
 }

--- a/conf/drupal.go
+++ b/conf/drupal.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ironstar-io/tokaido/system/console"
+	. "github.com/logrusorgru/aurora"
 	"github.com/manifoldco/promptui"
 )
 
@@ -21,7 +22,8 @@ func GetRootPath() string {
 		return filepath.Join(GetProjectPath(), dp)
 	}
 
-	log.Fatalf("Drupal path setting is missing.")
+	fmt.Println(Red("Drupal path setting is missing. Are you in a project directory?"))
+	os.Exit(1)
 	return ""
 }
 

--- a/conf/editor.go
+++ b/conf/editor.go
@@ -159,6 +159,10 @@ func MainMenu() {
 
 // TokaidoMenu is exposes Tokaido-level config settings
 func TokaidoMenu() {
+	gprj, err := GetGlobalProjectSettings()
+	if err != nil {
+		panic(err)
+	}
 	menu := []ConfigGenericString{
 		{
 			Name:    "Use Custom Compose File",
@@ -176,7 +180,7 @@ func TokaidoMenu() {
 		},
 		{
 			Name:    "PHP Version",
-			Default: "7.1",
+			Default: "7.2",
 			Type:    "value",
 			Current: GetConfig().Tokaido.Phpversion,
 			Detail:  "Use the latest version of PHP 7.1 or 7.2 when this version of Tokaido was compiled",
@@ -185,14 +189,14 @@ func TokaidoMenu() {
 			Name:    "PHP XDebug Support",
 			Default: "false",
 			Type:    "value",
-			Current: strconv.FormatBool(GetConfig().Tokaido.Xdebug),
+			Current: strconv.FormatBool(gprj.Xdebug.Enabled),
 			Detail:  "Set to 'true' to enable Xdebug support in the FPM and Admin containers",
 		},
 		{
-			Name:    "PHP XDebug Port",
+			Name:    "PHP FPM XDebug Port",
 			Default: "9000",
 			Type:    "value",
-			Current: GetConfig().Tokaido.Xdebugport,
+			Current: strconv.Itoa(gprj.Xdebug.FpmPort),
 			Detail:  "Set to port number your IDE is listening for incoming Xdebug connections for this project",
 		},
 		{
@@ -268,19 +272,17 @@ Current Setting: [{{ .Current | green }}]
 	case 2:
 		TokaidoPhpversionMenu()
 	case 3:
-		if GetConfig().Tokaido.Xdebug == true {
-			SetConfigValueByArgs([]string{"tokaido", "xdebug", "false"}, "project")
+		if gprj.Xdebug.Enabled == true {
+			SetGlobalConfigValueByArgs([]string{"global", "project", "xdebug", "enabled", "false"})
+			// SetConfigValueByArgs([]string{"tokaido", "xdebug", "false"}, "project")
 		} else {
-			SetConfigValueByArgs([]string{"tokaido", "xdebug", "true"}, "project")
-			if GetConfig().Tokaido.Xdebugport == "" {
-				SetConfigValueByArgs([]string{"tokaido", "xdebugport", "9000"}, "project")
-			}
+			SetGlobalConfigValueByArgs([]string{"global", "project", "xdebug", "enabled", "true"})
 		}
 		reloadConfig()
 		TokaidoMenu()
 	case 4:
-		res := newStringValue("Specify the port that your IDE is listening on for xdebug connections from this project:")
-		SetConfigValueByArgs([]string{"tokaido", "xdebugport", res}, "project")
+		res := newStringValue("Specify the port that your IDE is listening on for xdebug from PHP FPM:")
+		SetGlobalConfigValueByArgs([]string{"global", "project", "xdebug", "fpmport", res})
 		reloadConfig()
 		TokaidoMenu()
 	case 5:

--- a/conf/get_config.go
+++ b/conf/get_config.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"reflect"
@@ -41,6 +42,18 @@ func GetProjectPath() (path string) {
 	}
 
 	panic("Unexpected error resolving this project's path in the global config file")
+}
+
+// GetGlobalProjectSettings returns the current global conf object for the current project
+func GetGlobalProjectSettings() (*Project, error) {
+	c := GetConfig()
+	for _, v := range c.Global.Projects {
+		if v.Name == c.Tokaido.Project.Name {
+			return &v, nil
+		}
+	}
+
+	return &Project{}, fmt.Errorf("unable to find global project configuration")
 }
 
 // GetConfigValueByArgs - Get a config value based on the arguments sent from the command line

--- a/conf/struct.go
+++ b/conf/struct.go
@@ -2,8 +2,12 @@ package conf
 
 // Project is a singular entry of a project name and path used in global config
 type Project struct {
-	Name string `yaml:"name,omitempty"`
-	Path string `yaml:"path,omitempty"`
+	Name   string `yaml:"name,omitempty"`
+	Path   string `yaml:"path,omitempty"`
+	Xdebug struct {
+		Enabled bool `yaml:"enabled"`
+		FpmPort int  `yaml:"fpmport"`
+	} `yaml:"xdebug,omitempty"`
 }
 
 // Telemetry carries telemetry configuration settings
@@ -38,8 +42,6 @@ type Config struct {
 		Yes              bool   `yaml:"yes,omitempty"`
 		Phpversion       string `yaml:"phpversion"`
 		Stability        string `yaml:"stability"`
-		Xdebug           bool   `yaml:"xdebug"`
-		Xdebugport       string `yaml:"xdebugport"`
 		Project          struct {
 			Identifier string `yaml:"identifier"`
 			Name       string `yaml:"name"`
@@ -74,12 +76,6 @@ type Config struct {
 		Phpallowurlfopen     string `yaml:"phpallowurlfopen,omitempty"`
 	}
 	System struct {
-		Xdebug struct {
-			Port      string `yaml:"port,omitempty"`
-			Logpath   string `yaml:"logpath,omitempty"`
-			Enabled   bool   `yaml:"enabled"`
-			Autostart bool   `yaml:"autostart"`
-		} `yaml:"xdebug,omitempty"`
 		Syncsvc struct {
 			Systemdpath string `yaml:"systemdpath,omitempty"`
 			Launchdpath string `yaml:"launchdpath,omitempty"`

--- a/services/docker/generate.go
+++ b/services/docker/generate.go
@@ -94,7 +94,6 @@ func MarshalledDefaults() []byte {
 // UnmarshalledDefaults ...
 func UnmarshalledDefaults() conf.ComposeDotTok {
 	tokStruct := conf.ComposeDotTok{}
-	xdebugImageVersion := conf.GetConfig().Tokaido.Stability
 	phpVersion := conf.GetConfig().Tokaido.Phpversion
 
 	if conf.GetConfig().Global.Syncservice == "docker" {
@@ -193,13 +192,6 @@ func UnmarshalledDefaults() conf.ComposeDotTok {
 	err = yaml.Unmarshal(dockertmpl.StabilityLevel(phpVersion, conf.GetConfig().Tokaido.Stability), &tokStruct)
 	if err != nil {
 		log.Fatalf("Error updating stability version for containers in Compose file: %v", err)
-	}
-
-	if conf.GetConfig().Tokaido.Xdebug {
-		err = yaml.Unmarshal(dockertmpl.EnableXdebug(phpVersion, xdebugImageVersion), &tokStruct)
-		if err != nil {
-			log.Fatalf("Error enabling Xdebug in Compose file: %v", err)
-		}
 	}
 
 	err = yaml.Unmarshal(getCustomTok(), &tokStruct)

--- a/services/docker/templates/compose.go
+++ b/services/docker/templates/compose.go
@@ -154,16 +154,6 @@ func EnableMemcache(version string) []byte {
     image: memcached:` + version)
 }
 
-// EnableXdebug ...
-func EnableXdebug(phpVersion, xdebugImageVersion string) []byte {
-	v := calcPhpVersionString(phpVersion)
-	return []byte(`services:
-  fpm:
-    image: tokaido/php` + v + `-fpm-xdebug:` + xdebugImageVersion + `
-  drush:
-    image: tokaido/admin` + v + `-heavy-xdebug:` + xdebugImageVersion)
-}
-
 // ExternalVolumeDeclare ...
 func ExternalVolumeDeclare(name string) []byte {
 	return []byte(`volumes:

--- a/services/proxy/setup.go
+++ b/services/proxy/setup.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"log"
+	"strconv"
 
 	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/constants"
@@ -52,7 +53,7 @@ func ConfigureProjectNginx() {
 		return
 	}
 
-	pp := constants.HTTPSProtocol + h + ":" + string(constants.HaproxyInternalPort)
+	pp := constants.HTTPSProtocol + h + ":" + strconv.Itoa(constants.HaproxyInternalPort)
 
 	pn := conf.GetConfig().Tokaido.Project.Name
 	do := pn + `.` + constants.ProxyDomain

--- a/services/tok/init.go
+++ b/services/tok/init.go
@@ -42,10 +42,11 @@ func Init(yes, statuscheck bool) {
 	fmt.Println(Cyan("\n🚀  Tokaido is starting up!"))
 
 	// Create Tokaido configuration
-	conf.SetDrupalConfig("CUSTOM")
 	drupal.CheckSettings(cs)
+	conf.SetDrupalConfig("CUSTOM")
 	docker.FindOrCreateTokCompose()
 	ssh.GenerateKeys()
+
 	docker.CreateDatabaseVolume()
 	docker.CreateSiteVolume()
 	err := snapshots.Init()
@@ -157,7 +158,7 @@ func surveyMessage() {
 	rand.Seed(time.Now().UnixNano())
 	n := rand.Intn(6-1) + 1
 	if n == 3 {
-		fmt.Println(Sprintf("    How's Tokaido? Run '%s' to share your feedback.", Bold("tok survey")))
+		fmt.Println(Sprintf("🤗  How's Tokaido? Run '%s' to share your feedback.", Bold("tok survey")))
 	}
 }
 


### PR DESCRIPTION
fixes #161

With this update we move the FPM setting from the project config.yml file into the global.yml file on a per-project basis. This means that one user can enable xdebug with their own port number without impacting the performance or config of other users on the project.

XDebug also now comes bundled into the main FPM container and no longer requires maintenance of a dedicated FPM container. 

Finally, Xdebug is easier to enable with a single global setting: `tok config-set global project xdebug enabled true` 