### PR TITLE
Improved nightwatch support

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/ironstar-io/tokaido/conf"
@@ -20,6 +21,7 @@ var TestCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		initialize.TokConfig("test")
 		telemetry.SendCommand("test")
+		fmt.Println()
 		utils.CheckCmdHard("docker-compose")
 
 		docker.HardCheckTokCompose()

--- a/conf/drupal.go
+++ b/conf/drupal.go
@@ -40,7 +40,6 @@ func SetDrupalConfig(drupalType string) {
 	if (p == "") || (v == "") {
 		p, v = detectDrupalSettings()
 	}
-
 	CreateOrReplaceDrupalConfig(p, v)
 }
 
@@ -163,13 +162,12 @@ func CoreDrupalFile() string {
 	return path
 }
 
-// CoreDrupal8Path - Return the core Drupal 8 path for the users' installation
+// CoreDrupal8Path - Return the core Drupal 8 path
 func CoreDrupal8Path() string {
 	c := GetConfig()
-	tp := GetProjectPath()
 	rp := c.Drupal.Path
 
-	return filepath.Join(tp, rp, "core")
+	return filepath.Join("/tokaido/site", rp, "core")
 }
 
 // GetRootDir - Return the drupal root folder name without workdir

--- a/conf/editor.go
+++ b/conf/editor.go
@@ -475,7 +475,7 @@ func DatabaseMenu() {
 			Name:    "MySQL Version",
 			Type:    "menu",
 			Current: GetConfig().Database.Mysqlconfig.Version,
-			Default: "5.6",
+			Default: "5.7",
 			Detail:  "Set the MySQL Version if MySQL is used",
 		},
 		{

--- a/conf/get_config.go
+++ b/conf/get_config.go
@@ -22,7 +22,7 @@ func GetConfig() *Config {
 
 	// Create an empty global config file if on doesn't exist
 	gcPath := getConfigPath("global")
-	if fs.CheckExists(gcPath) {
+	if !fs.CheckExists(gcPath) {
 		WriteGlobalConfig(Global{})
 	}
 
@@ -48,11 +48,8 @@ func GetProjectPath() (path string) {
 		}
 	}
 
-	// Construct the path and save it to global config since it doesn't already exist
-	pr := fs.ProjectRoot()
-	RegisterProject(GetConfig().Tokaido.Project.Name, pr)
-
-	return pr
+	// The path isn't in global.yml yet, so we'll just return it based on the current project context
+	return fs.ProjectRoot()
 }
 
 // GetGlobalProjectSettings returns the current global conf object for the current project

--- a/conf/get_config.go
+++ b/conf/get_config.go
@@ -41,13 +41,18 @@ func GetConfig() *Config {
 
 // GetProjectPath returns the full system path to this project as it exists in the global.yml file
 func GetProjectPath() (path string) {
+	// If the path exists in the global config, return it
 	for _, v := range GetConfig().Global.Projects {
 		if v.Name == GetConfig().Tokaido.Project.Name {
 			return v.Path
 		}
 	}
 
-	panic("Unexpected error resolving this project's path in the global config file")
+	// Construct the path and save it to global config since it doesn't already exist
+	pr := fs.ProjectRoot()
+	RegisterProject(GetConfig().Tokaido.Project.Name, pr)
+
+	return pr
 }
 
 // GetGlobalProjectSettings returns the current global conf object for the current project

--- a/conf/struct.go
+++ b/conf/struct.go
@@ -112,6 +112,11 @@ type Services struct {
 		Volumes     []string          `yaml:"volumes,omitempty"`
 		Labels      map[string]string `yaml:"labels,omitempty"`
 	} `yaml:"unison,omitempty"`
+	Chromedriver struct {
+		Enabled bool     `yaml:"enabled,omitempty"`
+		Image   string   `yaml:"image,omitempty"`
+		Ports   []string `yaml:"ports,omitempty"`
+	} `yaml:"chromedriver,omitempty"`
 	Sync struct {
 		Image       string            `yaml:"image,omitempty"`
 		Hostname    string            `yaml:"hostname,omitempty"`

--- a/conf/struct.go
+++ b/conf/struct.go
@@ -88,7 +88,7 @@ type Config struct {
 		Syncsvc struct {
 			Systemdpath string `yaml:"systemdpath,omitempty"`
 			Launchdpath string `yaml:"launchdpath,omitempty"`
-			Enabled     bool   `yaml:"enabled"`
+			Enabled     bool   `yaml:"enabled,omitempty"`
 		} `yaml:"syncsvc,omitempty"`
 		Proxy struct {
 			Enabled bool `yaml:"enabled"`

--- a/conf/struct.go
+++ b/conf/struct.go
@@ -113,9 +113,10 @@ type Services struct {
 		Labels      map[string]string `yaml:"labels,omitempty"`
 	} `yaml:"unison,omitempty"`
 	Chromedriver struct {
-		Enabled bool     `yaml:"enabled,omitempty"`
-		Image   string   `yaml:"image,omitempty"`
-		Ports   []string `yaml:"ports,omitempty"`
+		Enabled     bool              `yaml:"enabled,omitempty"`
+		Environment map[string]string `yaml:"environment,omitempty"`
+		Image       string            `yaml:"image,omitempty"`
+		Ports       []string          `yaml:"ports,omitempty"`
 	} `yaml:"chromedriver,omitempty"`
 	Sync struct {
 		Image       string            `yaml:"image,omitempty"`

--- a/services/database/main.go
+++ b/services/database/main.go
@@ -1,0 +1,40 @@
+package database
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/ironstar-io/tokaido/services/docker"
+
+	_ "github.com/go-sql-driver/mysql" // Official docs recommend blank import
+)
+
+// Connect opens a connection to the named database
+func Connect(dbname string) (*sql.DB, error) {
+
+	port := docker.LocalPort("mysql", "3306")
+
+	db, err := sql.Open("mysql", "tokaido:tokaido@tcp(127.0.0.1:"+port+")/"+dbname)
+	if err != nil {
+		fmt.Println("err not nil")
+		return &sql.DB{}, err
+	}
+	// defer db.Close()
+
+	return db, nil
+}
+
+// ConnectRoot opens a connection to the named database as root
+func ConnectRoot(dbname string) (*sql.DB, error) {
+
+	port := docker.LocalPort("mysql", "3306")
+
+	db, err := sql.Open("mysql", "root:tokaido@tcp(127.0.0.1:"+port+")/"+dbname)
+	if err != nil {
+		fmt.Println("err not nil")
+		return &sql.DB{}, err
+	}
+	// defer db.Close()
+
+	return db, nil
+}

--- a/services/docker/generate.go
+++ b/services/docker/generate.go
@@ -232,6 +232,13 @@ func UnmarshalledDefaults() conf.ComposeDotTok {
 		}
 	}
 
+	if conf.GetConfig().Services.Chromedriver.Enabled {
+		err = yaml.Unmarshal(dockertmpl.EnableChromedriver(), &tokStruct)
+		if err != nil {
+			log.Fatalf("Error enabling Chromedriver in Compose file: %v", err)
+		}
+	}
+
 	// Set our stability version
 	err = yaml.Unmarshal(dockertmpl.StabilityLevel(phpVersion, conf.GetConfig().Tokaido.Stability), &tokStruct)
 	if err != nil {

--- a/services/docker/generate.go
+++ b/services/docker/generate.go
@@ -265,6 +265,7 @@ func getCustomTok() []byte {
 	dc.Services.Redis.Enabled = false
 	dc.Services.Mailhog.Enabled = false
 	dc.Services.Adminer.Enabled = false
+	dc.Services.Chromedriver.Enabled = false
 
 	cc, err := yaml.Marshal(dc)
 	if err != nil {

--- a/services/docker/templates/compose.go
+++ b/services/docker/templates/compose.go
@@ -163,11 +163,9 @@ func EnableChromedriver() []byte {
     labels:
       io.tokaido.managed: local
       io.tokaido.project: ` + conf.GetConfig().Tokaido.Project.Name + `
-    image: robcherry/docker-chromedriver:latest
+    image: drupalci/chromedriver:production
     ports:
-      - "4444"
-    environment:
-      CHROMEDRIVER_WHITELISTED_IPS: ""`)
+      - "9515"`)
 }
 
 // ExternalVolumeDeclare ...

--- a/services/docker/templates/compose.go
+++ b/services/docker/templates/compose.go
@@ -156,6 +156,20 @@ func EnableMemcache(version string) []byte {
     image: memcached:` + version)
 }
 
+// EnableChromedriver ...
+func EnableChromedriver() []byte {
+	return []byte(`services:
+  chromedriver:
+    labels:
+      io.tokaido.managed: local
+      io.tokaido.project: ` + conf.GetConfig().Tokaido.Project.Name + `
+    image: robcherry/docker-chromedriver:latest
+    ports:
+      - "4444"
+    environment:
+      CHROMEDRIVER_WHITELISTED_IPS: ""`)
+}
+
 // ExternalVolumeDeclare ...
 func ExternalVolumeDeclare(name string) []byte {
 	return []byte(`volumes:

--- a/services/telemetry/main.go
+++ b/services/telemetry/main.go
@@ -55,7 +55,7 @@ func RequestOptIn() {
 	confirmation := utils.ConfirmationPrompt(`
 To help us improve Tokaido, you can opt-in to sending anonymous usage data.
 
-The data we collect can not be used to identify you and will never be sold, licensed, or
+The data we collect cannot be used to identify you and will never be sold, licensed, or
 transferred to a third party. We commit to sharing summary reports on this data (but not
 the raw data itself) with the community to help us all understand how Drupal is used.
 

--- a/services/testing/nightwatch/drupal.go
+++ b/services/testing/nightwatch/drupal.go
@@ -60,10 +60,15 @@ func checkNightwatchConfig() error {
 	dr := conf.GetConfig().Drupal.Path
 
 	nightwatchConfPath := filepath.Join(pr, dr, "core/tests/Drupal/Nightwatch/nightwatch.conf.js")
-	nightwatchOk := fs.Contains(nightwatchConfPath, "acceptInsecureCerts: true")
 	utils.DebugString("nightwatchConfPath: " + nightwatchConfPath)
-	utils.DebugString("nightwatchOk: " + strconv.FormatBool(nightwatchOk))
+	if !fs.CheckExists(nightwatchConfPath) {
+		fmt.Println(Red("Expected nightwatch configuration file was not found: "), nightwatchConfPath)
+		fmt.Println(Red("Tokaido cannot continue. Is your Drupal Core installation working?"))
+		os.Exit(1)
+	}
 
+	nightwatchOk := fs.Contains(nightwatchConfPath, "acceptInsecureCerts: true")
+	utils.DebugString("nightwatchOk: " + strconv.FormatBool(nightwatchOk))
 	if !nightwatchOk {
 		ok = false
 		fmt.Println(Red("Tokaido tests via HTTPS, but Druapl's Nightwatch config only supports HTTP."))
@@ -75,10 +80,15 @@ func checkNightwatchConfig() error {
 	}
 
 	drupalUserIsLoggedInPath := filepath.Join(pr, dr, "core/tests/Drupal/Nightwatch/Commands/drupalUserIsLoggedIn.js")
-	drupalUserIsLoggedInOk := fs.Contains(drupalUserIsLoggedInPath, "/^SSESS/")
 	utils.DebugString("drupalUserIsLoggedInPath: " + drupalUserIsLoggedInPath)
-	utils.DebugString("drupalUserIsLoggedInOk: " + strconv.FormatBool(drupalUserIsLoggedInOk))
+	if !fs.CheckExists(drupalUserIsLoggedInPath) {
+		fmt.Println(Red("Expected nightwatch command file was not found: "), drupalUserIsLoggedInPath)
+		fmt.Println(Red("Tokaido cannot continue. Is your Drupal Core installation working?"))
+		os.Exit(1)
+	}
 
+	drupalUserIsLoggedInOk := fs.Contains(drupalUserIsLoggedInPath, "/^SSESS/")
+	utils.DebugString("drupalUserIsLoggedInOk: " + strconv.FormatBool(drupalUserIsLoggedInOk))
 	if !drupalUserIsLoggedInOk {
 		ok = false
 		fmt.Println(Red("Tokaido tests via HTTPS, but Druapl's Nightwatch config only supports HTTP."))

--- a/services/testing/nightwatch/main.go
+++ b/services/testing/nightwatch/main.go
@@ -54,6 +54,10 @@ func checkCompatibility() error {
 	return nil
 }
 
+func enableChromedriver() {
+	conf.SetConfigValueByArgs([]string{"services", "chromedriver", "enabled", "true"}, "project")
+}
+
 // RunDrupalTests - Run Drupal Nightwatch tests. See: https://github.com/drupal/drupal/blob/8.6.x/core/tests/README.md#nightwatch-tests
 func RunDrupalTests() error {
 	err := CheckLocalDrupal()
@@ -66,6 +70,8 @@ func RunDrupalTests() error {
 	if err != nil {
 		return err
 	}
+
+	enableChromedriver()
 
 	checkPHPUnit()
 	yarnInstall()

--- a/services/testing/nightwatch/main.go
+++ b/services/testing/nightwatch/main.go
@@ -2,69 +2,38 @@ package nightwatch
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/ironstar-io/tokaido/conf"
+	"github.com/ironstar-io/tokaido/services/database"
 	"github.com/ironstar-io/tokaido/services/docker"
 	"github.com/ironstar-io/tokaido/services/proxy"
 	"github.com/ironstar-io/tokaido/services/testing/nightwatch/goos"
+	"github.com/ironstar-io/tokaido/services/tok"
 	"github.com/ironstar-io/tokaido/system/console"
 	"github.com/ironstar-io/tokaido/system/fs"
 	"github.com/ironstar-io/tokaido/system/ssh"
+	"github.com/ironstar-io/tokaido/utils"
+
+	. "github.com/logrusorgru/aurora"
 )
-
-func calcSiteURL() string {
-	if proxy.CheckProxyUp() == true {
-		return proxy.GetProxyURL()
-	}
-
-	return "https://localhost:" + docker.LocalPort("haproxy", "8443")
-}
-
-// Copy and amend .env file if it doesn't already exist
-func configureEnvFile() {
-	env := filepath.Join(conf.CoreDrupal8Path(), ".env")
-	if fs.CheckExists(env) == false {
-		generateEnvFile(env)
-	}
-}
-
-func yarnInstall() error {
-	cp := conf.CoreDrupal8Path()
-
-	fmt.Println("    Ensuring Nightwatch dependencies are installed")
-	ssh.StreamConnectCommand([]string{"cd", cp, "&&", "yarn", "install"})
-
-	// _, err := utils.CommandSubSplitOutputContext(d, "yarn", "check", "--verify-tree")
-	// if err != nil {
-	// 	fmt.Println()
-	// 	console.Println("🧶   Nightwatch dependencies haven't been installed yet. Attempting to install with yarn", "")
-	// 	utils.StreamOSCmdContext(d, "yarn", "install")
-	// }
-
-	return nil
-}
-
-func yarnTestNightwatch() {
-	cp := conf.CoreDrupal8Path()
-
-	console.Println("👩‍💻  Tokaido is starting a Nightwatch test run with the command `yarn test:nightwatch`\n", "")
-
-	ssh.StreamConnectCommand([]string{"cd", cp, "&&", "yarn", "test:nightwatch"})
-
-}
-
-func checkCompatibility() error {
-	goos.CheckDependencies()
-	return nil
-}
-
-func enableChromedriver() {
-	conf.SetConfigValueByArgs([]string{"services", "chromedriver", "enabled", "true"}, "project")
-}
 
 // RunDrupalTests - Run Drupal Nightwatch tests. See: https://github.com/drupal/drupal/blob/8.6.x/core/tests/README.md#nightwatch-tests
 func RunDrupalTests() error {
+	fmt.Println(Blue("Please note 'tok test' is a beta feature and under active development"))
+	fmt.Println(Blue("We'd to hear what you think - you can use `tok survey` to send us feedback"))
+	fmt.Println(Blue("If you'd like to contribute by discussing test frameworks and included tests"))
+	fmt.Println(Blue("please find us on the #tokaido channel of the official Drupal Slack"))
+	fmt.Println()
+
+	// Create the 'tests' database if it doesn't exist
+	dbOk := checkMysqlTestsDatabase()
+	if !dbOk {
+		createMysqlTestsDatabase()
+	}
+
 	err := CheckLocalDrupal()
 	if err != nil {
 		console.Println("⚠️   "+err.Error(), "")
@@ -83,7 +52,129 @@ func RunDrupalTests() error {
 
 	configureEnvFile()
 
+	checkNightwatchConfig()
+
 	yarnTestNightwatch()
 
 	return nil
+}
+
+func calcSiteURL() string {
+	if proxy.CheckProxyUp() == true {
+		return proxy.GetProxyURL()
+	}
+
+	return "https://localhost:" + docker.LocalPort("haproxy", "8443")
+}
+
+// Copy and amend .env file if it doesn't already exist
+func configureEnvFile() {
+	pr := conf.GetProjectPath()
+	dr := conf.GetConfig().Drupal.Path
+	env := filepath.Join(pr, dr, "core", ".env")
+	if fs.CheckExists(env) == false {
+		fmt.Println(Cyan(fmt.Sprintf("📋  Adding Nightwatch config to %s", env)))
+		generateEnvFile(env)
+	}
+}
+
+func yarnInstall() error {
+	cp := conf.CoreDrupal8Path()
+
+	fmt.Println(Cyan("🦉  Ensuring Nightwatch dependencies are installed"))
+	ssh.StreamConnectCommand([]string{"cd", cp, "&&", "yarn", "install"})
+	return nil
+}
+
+func yarnTestNightwatch() {
+	cp := conf.CoreDrupal8Path()
+
+	fmt.Println(Cyan("👩‍💻  Tokaido is starting a Nightwatch test run with the command `yarn test:nightwatch`"))
+	fmt.Println(Yellow(Sprintf("    If you want to run this command directly, you need run it from %s", Bold("inside the Tokaido SSH container"))))
+
+	ssh.StreamConnectCommand([]string{"cd", cp, "&&", "yarn", "test:nightwatch"})
+
+}
+
+func checkCompatibility() error {
+	goos.CheckDependencies()
+	return nil
+}
+
+func enableChromedriver() {
+	if !conf.GetConfig().Services.Chromedriver.Enabled {
+		conf.SetConfigValueByArgs([]string{"services", "chromedriver", "enabled", "true"}, "project")
+	}
+
+	if !docker.StatusCheck("chromedriver", conf.GetConfig().Tokaido.Project.Name) {
+		fmt.Println(Cyan("👾  Restarting Tokaido with Chromedriver enabled"))
+		tok.Init(true, false)
+
+	}
+}
+
+// checkMysqlTestsDatabase spawns a 'tests' databases in the Tokaido MySQL instance
+func checkMysqlTestsDatabase() bool {
+	// Check to see if the database already exists
+	db, err := database.Connect("tests")
+	if err != nil {
+		fmt.Println(Red("Error: Could not connect to the database container failed. Have you run `tok up`?"))
+		utils.DebugString(err.Error())
+		os.Exit(1)
+	}
+
+	err = db.Ping()
+	if err != nil {
+		// The database connection was opened but failed, so the provided database doesn't exist
+		return false
+	}
+
+	return true
+}
+
+func createMysqlTestsDatabase() {
+	fmt.Println(Cyan("    Creating a new 'tests' database"))
+
+	db, err := database.ConnectRoot("tokaido")
+	if err != nil {
+		fmt.Println(Red("Error: Could not connect to the database container failed. Have you run `tok up`?"))
+		utils.DebugString(err.Error())
+		os.Exit(1)
+	}
+
+	// Create the database
+	utils.DebugString("Creating test database")
+	_, err = db.Exec("CREATE DATABASE tests;")
+	if err != nil {
+		fmt.Println(Red("Error: Could not create the tests database: "), err.Error())
+		utils.DebugString(err.Error())
+		os.Exit(1)
+	}
+
+	// Grant 'tokaido' user access
+	utils.DebugString("Creating full access to 'tests' database to 'tokaido' user")
+	_, err = db.Exec("GRANT ALL ON tests.* TO 'tokaido'@'%';")
+	if err != nil {
+		fmt.Println(Red("Error: Could not grant access to the tests database: "), err.Error())
+		utils.DebugString(err.Error())
+		os.Exit(1)
+	}
+
+	// Flush
+	utils.DebugString("Flushing privileges")
+	_, err = db.Exec("FLUSH PRIVILEGES;")
+	if err != nil {
+		fmt.Println(Red("Error: Could not successfully flush privileges: "), err.Error())
+		utils.DebugString(err.Error())
+		os.Exit(1)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	// See if the creation was successful
+	success := checkMysqlTestsDatabase()
+	if !success {
+		fmt.Println(Red("Error: Tokaido was not able to successfully create the 'tests' database"))
+		os.Exit(1)
+	}
 }

--- a/services/testing/nightwatch/main.go
+++ b/services/testing/nightwatch/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ironstar-io/tokaido/services/testing/nightwatch/goos"
 	"github.com/ironstar-io/tokaido/system/console"
 	"github.com/ironstar-io/tokaido/system/fs"
-	"github.com/ironstar-io/tokaido/utils"
+	"github.com/ironstar-io/tokaido/system/ssh"
 )
 
 func calcSiteURL() string {
@@ -25,28 +25,33 @@ func calcSiteURL() string {
 func configureEnvFile() {
 	env := filepath.Join(conf.CoreDrupal8Path(), ".env")
 	if fs.CheckExists(env) == false {
-		generateEnvFile(env, calcSiteURL())
+		generateEnvFile(env)
 	}
 }
 
 func yarnInstall() error {
-	d := conf.CoreDrupal8Path()
+	cp := conf.CoreDrupal8Path()
 
-	_, err := utils.CommandSubSplitOutputContext(d, "yarn", "check", "--verify-tree")
-	if err != nil {
-		fmt.Println()
-		console.Println("🧶   Nightwatch dependencies haven't been installed yet. Attempting to install with yarn", "")
-		utils.StreamOSCmdContext(d, "yarn", "install")
-	}
+	fmt.Println("    Ensuring Nightwatch dependencies are installed")
+	ssh.StreamConnectCommand([]string{"cd", cp, "&&", "yarn", "install"})
+
+	// _, err := utils.CommandSubSplitOutputContext(d, "yarn", "check", "--verify-tree")
+	// if err != nil {
+	// 	fmt.Println()
+	// 	console.Println("🧶   Nightwatch dependencies haven't been installed yet. Attempting to install with yarn", "")
+	// 	utils.StreamOSCmdContext(d, "yarn", "install")
+	// }
 
 	return nil
 }
 
 func yarnTestNightwatch() {
-	d := conf.CoreDrupal8Path()
+	cp := conf.CoreDrupal8Path()
 
 	console.Println("👩‍💻  Tokaido is starting a Nightwatch test run with the command `yarn test:nightwatch`\n", "")
-	utils.StreamOSCmdContext(d, "yarn", "test:nightwatch")
+
+	ssh.StreamConnectCommand([]string{"cd", cp, "&&", "yarn", "test:nightwatch"})
+
 }
 
 func checkCompatibility() error {

--- a/services/testing/nightwatch/template.go
+++ b/services/testing/nightwatch/template.go
@@ -2,11 +2,11 @@ package nightwatch
 
 import "github.com/ironstar-io/tokaido/system/fs"
 
-func generateEnvFile(path, baseURL string) {
-	fs.TouchByteArray(path, buildEnvFileContents(baseURL))
+func generateEnvFile(path string) {
+	fs.TouchByteArray(path, buildEnvFileContents())
 }
 
-func buildEnvFileContents(baseURL string) []byte {
+func buildEnvFileContents() []byte {
 	return []byte(`# This is a dotenv file used by JavaScript tasks.
 # Copy this to '.env' to override.
 
@@ -18,7 +18,7 @@ func buildEnvFileContents(baseURL string) []byte {
 # don't already have one running, e.g. Apache, you can use PHP's built-in web
 # server by running the following command in your Drupal root folder:
 # php -S localhost:8888 .ht.router.php
-DRUPAL_TEST_BASE_URL=` + baseURL + `
+DRUPAL_TEST_BASE_URL=http://nginx:8082
 
 # Tests need to be executed with a user in the same group as the web server
 # user.

--- a/services/testing/nightwatch/template.go
+++ b/services/testing/nightwatch/template.go
@@ -7,9 +7,7 @@ func generateEnvFile(path string) {
 }
 
 func buildEnvFileContents() []byte {
-	return []byte(`# This is a dotenv file used by JavaScript tasks.
-# Copy this to '.env' to override.
-
+	return []byte(`
 #############################
 # General Test Environment #
 #############################
@@ -18,7 +16,7 @@ func buildEnvFileContents() []byte {
 # don't already have one running, e.g. Apache, you can use PHP's built-in web
 # server by running the following command in your Drupal root folder:
 # php -S localhost:8888 .ht.router.php
-DRUPAL_TEST_BASE_URL=http://nginx:8082
+DRUPAL_TEST_BASE_URL=https://haproxy:8443
 
 # Tests need to be executed with a user in the same group as the web server
 # user.
@@ -26,7 +24,8 @@ DRUPAL_TEST_BASE_URL=http://nginx:8082
 
 # By default we use sqlite as database. Use
 # mysql://username:password@localhost/databasename#table_prefix for mysql.
-DRUPAL_TEST_DB_URL=sqlite://localhost/sites/default/files/db.sqlite
+#DRUPAL_TEST_DB_URL=sqlite://localhost/sites/default/files/db.sqlite
+DRUPAL_TEST_DB_URL=mysql://tokaido:tokaido@mysql/tests
 
 #############
 # Webdriver #
@@ -35,7 +34,7 @@ DRUPAL_TEST_DB_URL=sqlite://localhost/sites/default/files/db.sqlite
 # If Chromedriver is running as a service elsewhere, set it here.
 # When using DRUPAL_TEST_CHROMEDRIVER_AUTOSTART leave this at the default settings.
 DRUPAL_TEST_WEBDRIVER_HOSTNAME=chromedriver
-DRUPAL_TEST_WEBDRIVER_PORT=4444
+DRUPAL_TEST_WEBDRIVER_PORT=9515
 
 # If using Selenium, override the path prefix here.
 # See http://nightwatchjs.org/gettingstarted#browser-drivers-setup
@@ -48,7 +47,7 @@ DRUPAL_TEST_WEBDRIVER_PORT=4444
 # Automatically start chromedriver for local development. Set to false when you
 # use your own webdriver or chromedriver setup.
 # Also set it to false when you use a different browser for testing.
-DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=true
+DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=false
 
 # A list of arguments to pass to Chrome, separated by spaces
 # e.g. '--disable-gpu --headless --no-sandbox'.

--- a/services/testing/nightwatch/template.go
+++ b/services/testing/nightwatch/template.go
@@ -34,8 +34,8 @@ DRUPAL_TEST_DB_URL=sqlite://localhost/sites/default/files/db.sqlite
 
 # If Chromedriver is running as a service elsewhere, set it here.
 # When using DRUPAL_TEST_CHROMEDRIVER_AUTOSTART leave this at the default settings.
-DRUPAL_TEST_WEBDRIVER_HOSTNAME=localhost
-DRUPAL_TEST_WEBDRIVER_PORT=9515
+DRUPAL_TEST_WEBDRIVER_HOSTNAME=chromedriver
+DRUPAL_TEST_WEBDRIVER_PORT=4444
 
 # If using Selenium, override the path prefix here.
 # See http://nightwatchjs.org/gettingstarted#browser-drivers-setup

--- a/services/tok/ps.go
+++ b/services/tok/ps.go
@@ -36,6 +36,16 @@ func Ps() {
 		}
 	}
 
+	if conf.GetConfig().Services.Chromedriver.Enabled {
+		chromedriver := docker.GetContainer("chromedriver", pn)
+		if chromedriver.State == "running" {
+			o = append(o, Sprintf("chromedriver|-|-|%s", Green(chromedriver.State)))
+		} else {
+			o = append(o, Sprintf("chromedriver|-|-|%s", Yellow("offline")))
+			failure = true
+		}
+	}
+
 	// Output Drush status
 	admin := docker.GetContainer("drush", pn)
 	if admin.State == "running" {


### PR DESCRIPTION
This PR implements a significant update to how `tok test` runs. In particular:

- Nightwatch (NW) is now run from _inside_ Tokaido, rather than trying to run on the user's host
- If not running, a Chromedriver container is added to docker-compose which is then restarted
- NW is pointed at the haproxy container, and the user is alerted if they need to change the core NW config files to support HTTPS-based tests (Drupal core only works with HTTP at the moment, it seems)
- A mysql Service is added which can be used to automatically created a 'tests' database so that the main tokaido database isn't changed by the tests
- Added a lot more debug output to show what is going on

This definitely isn't the end of our 'tok test' functionality, and I've now labelled the feature as 'beta' and asked users for help and feedback when using it. Overall Nightwatch feels like the wrong fit for what we want, and we might end up swapping to Behat or some other framework depending on what users have to say. 
