### PR TITLE
Fix/missing networks in proxy

### DIFF
--- a/services/docker/containers.go
+++ b/services/docker/containers.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -12,6 +13,7 @@ import (
 // getContainerState returns the state of a specified container
 func getContainerState(name, project string) (state string, err error) {
 	dcli := GetAPIClient()
+	project = strings.ToLower(project)
 
 	filter := filters.NewArgs()
 	filter.Add("name", project+"_"+name)
@@ -42,6 +44,7 @@ func getContainerState(name, project string) (state string, err error) {
 // GetContainers returns all containers for a project
 func GetContainers(project string) *[]types.Container {
 	dcli := GetAPIClient()
+	project = strings.ToLower(project)
 
 	filter := filters.NewArgs()
 	filter.Add("name", project+"_")
@@ -59,6 +62,7 @@ func GetContainers(project string) *[]types.Container {
 // GetContainer returns a docker Container object for the specified container, if it exists
 func GetContainer(name, project string) types.Container {
 	dcli := GetAPIClient()
+	project = strings.ToLower(project)
 
 	filter := filters.NewArgs()
 	cn := project + "_" + name

--- a/services/docker/general.go
+++ b/services/docker/general.go
@@ -98,6 +98,13 @@ func GetContainerName(name string) (string, error) {
 	return cn, nil
 }
 
+// GetNetworkName takes a project name and returns a matching network name
+// that complies with the same sanitisation that docker compose uses when
+// it auto-generates networks from compose files
+func GetNetworkName(pn string) string {
+	return strings.ToLower(strings.Replace(pn, ".", "", -1)) + "_default"
+}
+
 // GetContainerIP ...
 func GetContainerIP(name string) (string, error) {
 	cn, err := GetContainerName(name)

--- a/services/docker/network.go
+++ b/services/docker/network.go
@@ -9,10 +9,10 @@ import (
 
 // CheckNetworkUp ...
 func CheckNetworkUp() bool {
-	p := conf.GetConfig().Tokaido.Project.Name
+	p := strings.ToLower(conf.GetConfig().Tokaido.Project.Name)
 
 	// Periods being replaced in recent versions of Docker for network names
-	n := strings.Replace(p, ".", "", -1) + "_default"
+	n := GetNetworkName(p)
 
 	_, err := utils.CommandSubSplitOutput("docker", "network", "inspect", n)
 	if err != nil {
@@ -25,7 +25,7 @@ func CheckNetworkUp() bool {
 // GetGateway - Get the Gateway IP adress of the docker network
 func GetGateway(projectName string) string {
 	// Periods being replaced in recent versions of Docker for network names
-	n := strings.Replace(projectName, ".", "", -1) + "_default"
+	n := GetNetworkName(projectName)
 
 	gatewayLine := utils.BashStringCmd("docker network inspect " + n + " | grep Gateway")
 

--- a/services/proxy/compose-generate.go
+++ b/services/proxy/compose-generate.go
@@ -32,9 +32,11 @@ func GenerateProxyDockerCompose() {
 		}
 	}
 
-	dc.Services.Proxy.Networks = append(dc.Services.Proxy.Networks, nn)
+	// build the list of networks that are attached to the proxy service itself
+	dc.Services.Proxy.Networks = buildProxyServiceNetworkAttachments()
 
-	n := buildNetworks(dc.Services.Proxy.Networks)
+	// build the list of networks as part of the base 'networks:' tree in docker compose
+	n := buildProxyExternalNetworkList()
 
 	cy, err := yaml.Marshal(&dc)
 	if err != nil {

--- a/services/proxy/compose-generate.go
+++ b/services/proxy/compose-generate.go
@@ -2,11 +2,11 @@ package proxy
 
 import (
 	"github.com/ironstar-io/tokaido/conf"
+	"github.com/ironstar-io/tokaido/services/docker"
 	"github.com/ironstar-io/tokaido/system/fs"
 	"github.com/ironstar-io/tokaido/utils"
 
 	"log"
-	"strings"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -16,7 +16,8 @@ func GenerateProxyDockerCompose() {
 	utils.DebugString("generating proxy compose file")
 	dc := DockerCompose{}
 	pn := conf.GetConfig().Tokaido.Project.Name
-	nn := strings.Replace(pn, ".", "", -1) + "_default"
+	nn := docker.GetNetworkName(pn)
+	utils.DebugString("resolved network name is: " + nn)
 
 	if conf.GetConfig().Global.Syncservice == "unison" {
 		err := yaml.Unmarshal(ComposeDefaultsUnison(), &dc)

--- a/services/proxy/compose-remove.go
+++ b/services/proxy/compose-remove.go
@@ -2,19 +2,19 @@ package proxy
 
 import (
 	"github.com/ironstar-io/tokaido/conf"
+	"github.com/ironstar-io/tokaido/services/docker"
 	"github.com/ironstar-io/tokaido/system/fs"
 	"github.com/ironstar-io/tokaido/system/version"
 	yaml "gopkg.in/yaml.v2"
 
 	"log"
-	"strings"
 )
 
 // RemoveProjectFromDockerCompose ...
 func RemoveProjectFromDockerCompose() {
 	dc := DockerCompose{}
 	pn := conf.GetConfig().Tokaido.Project.Name
-	nn := strings.Replace(pn, ".", "", -1) + "_default"
+	nn := docker.GetNetworkName(pn)
 	uv := version.GetUnisonVersion()
 
 	var err error

--- a/services/proxy/compose-remove.go
+++ b/services/proxy/compose-remove.go
@@ -36,7 +36,7 @@ func RemoveProjectFromDockerCompose() {
 		log.Fatalf("Error setting Unison version: %v", err)
 	}
 
-	// Find and remove the project network
+	// Find and remove the project network if it is duplicated
 	for i, v := range dc.Services.Proxy.Networks {
 		if v == nn {
 			dc.Services.Proxy.Networks = append(dc.Services.Proxy.Networks[:i], dc.Services.Proxy.Networks[i+1:]...)
@@ -44,7 +44,7 @@ func RemoveProjectFromDockerCompose() {
 		}
 	}
 
-	n := buildNetworks(dc.Services.Proxy.Networks)
+	n := buildProxyExternalNetworkList()
 
 	cy, err := yaml.Marshal(&dc)
 	if err != nil {

--- a/services/proxy/destroy.go
+++ b/services/proxy/destroy.go
@@ -35,7 +35,7 @@ func DestroyProject() {
 
 // RemoveNetwork ...
 func RemoveNetwork() {
-	n := conf.GetConfig().Tokaido.Project.Name + "_default"
+	n := docker.GetNetworkName(conf.GetConfig().Tokaido.Project.Name)
 
 	err := DisconnectNetworkEndpoint(n, proxyNetworkName)
 	if err != nil {


### PR DESCRIPTION
fixes an issue the proxy service wasn't marshalling the network list correctly and just used the current project. 

This patch causes the proxy to look up all projects in ~/.tok/global.yml and adds them if their corresponding docker network still exists. 