### PR TITLE
185/fix leaking settings

### DIFF
--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -24,7 +24,7 @@ var RebuildCmd = &cobra.Command{
 		docker.Stop()
 		unison.UnloadSyncService(conf.GetConfig().Tokaido.Project.Name)
 
-		tok.Init(true, false)
+		tok.Init(true, false, false)
 
 		tok.InitMessage()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,6 +70,7 @@ func RootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug mode, command output is printed to the console")
 
 	OpenCmd.PersistentFlags().BoolVarP(&adminFlag, "admin", "", false, "Create a one-time admin login URL and open")
+	UpCmd.PersistentFlags().BoolVarP(&noPullImagesFlag, "no-pull-images", "", false, "Stop Tokaido from downloaded the latest Docker images")
 	SnapshotNewCmd.PersistentFlags().StringVarP(&nameFlag, "name", "n", "", "Specify a name to be added to the snapshot name. If not specified, Tokaido will only use the current UTC date and time")
 
 	NewCmd.PersistentFlags().StringVarP(&templateFlag, "template", "t", "", "Specify a template to use such as drupal8-standard. See templates at: https://github.com/ironstar-io/tokaido-drupal-package-builder")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var noPullImagesFlag bool
+
 // UpCmd - `tok up`
 var UpCmd = &cobra.Command{
 	Use:   "up",
@@ -19,7 +21,7 @@ var UpCmd = &cobra.Command{
 		telemetry.SendCommand("up")
 		utils.CheckCmdHard("docker-compose")
 
-		tok.Init(conf.GetConfig().Tokaido.Yes, true)
+		tok.Init(conf.GetConfig().Tokaido.Yes, true, noPullImagesFlag)
 		tok.InitMessage()
 	},
 }

--- a/conf/set_config.go
+++ b/conf/set_config.go
@@ -45,6 +45,7 @@ func SetConfigValueByArgs(args []string, configType string) {
 	if configType == "project" {
 		// These values must not be written to the project config file so we reset them to nil or empty
 		runningConfig.Global.Syncservice = ""
+		runningConfig.Global.Proxy.Enabled = false
 		runningConfig.Global.Projects = nil
 		runningConfig.Global.Telemetry = Telemetry{}
 

--- a/conf/struct.go
+++ b/conf/struct.go
@@ -21,6 +21,9 @@ type Global struct {
 	Syncservice string    `yaml:"syncservice,omitempty"`
 	Projects    []Project `yaml:"projects,omitempty"`
 	Telemetry   Telemetry `yaml:"telemetry,omitempty"`
+	Proxy       struct {
+		Enabled bool `yaml:"enabled"`
+	} `yaml:"proxy,omitempty"`
 }
 
 // Config the application's configuration
@@ -84,16 +87,6 @@ type Config struct {
 		Phpmaxfileuploads    string `yaml:"phpmaxfileuploads,omitempty"`
 		Phpallowurlfopen     string `yaml:"phpallowurlfopen,omitempty"`
 	}
-	System struct {
-		Syncsvc struct {
-			Systemdpath string `yaml:"systemdpath,omitempty"`
-			Launchdpath string `yaml:"launchdpath,omitempty"`
-			Enabled     bool   `yaml:"enabled,omitempty"`
-		} `yaml:"syncsvc,omitempty"`
-		Proxy struct {
-			Enabled bool `yaml:"enabled"`
-		} `yaml:"proxy,omitempty"`
-	} `yaml:"system,omitempty"`
 	Services Services `yaml:"services,omitempty"`
 }
 

--- a/initialize/main.go
+++ b/initialize/main.go
@@ -65,8 +65,8 @@ func readProjectConfig(command string) {
 		viper.SetDefault("Global.Syncservice", "unison")
 	}
 
-	viper.SetDefault("System.Syncsvc.Launchdpath", filepath.Join(fs.HomeDir(), "/Library/LaunchAgents/"))
-	viper.SetDefault("System.Syncsvc.Systemdpath", filepath.Join(fs.HomeDir(), "/.config/systemd/user/"))
+	viper.SetDefault("Global.Syncsvc.Launchdpath", filepath.Join(fs.HomeDir(), "/Library/LaunchAgents/"))
+	viper.SetDefault("Global.Syncsvc.Systemdpath", filepath.Join(fs.HomeDir(), "/.config/systemd/user/"))
 
 	viper.SetDefault("Tokaido.Customcompose", viper.GetBool("customCompose"))
 	viper.SetDefault("Tokaido.Debug", viper.GetBool("debug"))
@@ -81,8 +81,8 @@ func readProjectConfig(command string) {
 	viper.SetDefault("Drupal.FilePublicPath", "")
 	viper.SetDefault("Drupal.FilePrivatePath", constants.DefaultDrupalPrivatePath)
 	viper.SetDefault("Drupal.FileTemporaryPath", constants.DefaultDrupalTemporaryPath)
-	viper.SetDefault("System.Syncsvc.Enabled", true)
-	viper.SetDefault("System.Proxy.Enabled", true)
+	viper.SetDefault("Global.Syncsvc.Enabled", true)
+	viper.SetDefault("Global.Proxy.Enabled", true)
 
 	if command == "new" {
 		viper.SetDefault("Services.Adminer.Enabled", true)

--- a/services/testing/nightwatch/main.go
+++ b/services/testing/nightwatch/main.go
@@ -108,7 +108,7 @@ func enableChromedriver() {
 
 	if !docker.StatusCheck("chromedriver", conf.GetConfig().Tokaido.Project.Name) {
 		fmt.Println(Cyan("👾  Restarting Tokaido with Chromedriver enabled"))
-		tok.Init(true, false)
+		tok.Init(true, false, false)
 
 	}
 }

--- a/services/tok/init.go
+++ b/services/tok/init.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Init - The core run sheet of `tok up`
-func Init(yes, statuscheck bool) {
+func Init(yes, statuscheck, noPullImagesFlag bool) {
 	c := conf.GetConfig()
 	cs := "ASK"
 	if yes {
@@ -81,11 +81,9 @@ func Init(yes, statuscheck bool) {
 		if s == "stopped" {
 			unison.Sync(c.Tokaido.Project.Name)
 		}
-		if c.System.Syncsvc.Enabled {
-			fmt.Println()
-			console.Println(`🔄  Creating a background process to sync your local repo into the Tokaido environment`, "")
-			unison.CreateSyncService(c.Tokaido.Project.Name, pr)
-		}
+		fmt.Println()
+		console.Println(`🔄  Creating a background process to sync your local repo into the Tokaido environment`, "")
+		unison.CreateSyncService(c.Tokaido.Project.Name, pr)
 	}
 
 	if c.Global.Syncservice == "fusion" {
@@ -97,8 +95,12 @@ func Init(yes, statuscheck bool) {
 		console.SpinPersist(wo, "🚛", "Initial sync completed")
 	}
 
-	fmt.Println("🤖  Downloading the latest Docker images")
-	docker.PullImages()
+	if noPullImagesFlag {
+		fmt.Println("    Not downloading the latest Docker images")
+	} else {
+		fmt.Println("🤖  Downloading the latest Docker images")
+		docker.PullImages()
+	}
 
 	console.Println("🚅  Starting your Drupal environment", "")
 	docker.Up()
@@ -107,7 +109,7 @@ func Init(yes, statuscheck bool) {
 	drupal.ConfigureSSH()
 	xdebug.Configure()
 
-	if c.System.Proxy.Enabled {
+	if c.Global.Proxy.Enabled {
 		// This step can't be in a spinner because the spinner can't ask for user input during the SSL trust stage.
 		console.Println(`🔐  Setting up HTTPS access...`, "")
 		proxy.Setup()

--- a/services/tok/new.go
+++ b/services/tok/new.go
@@ -207,7 +207,7 @@ func New(args []string, requestTemplate string) {
 
 	// Start the environment
 	initialize.TokConfig("up")
-	Init(true, false)
+	Init(true, false, false)
 
 	// Run the post-up custom installation commands
 	l := len(template.PostUpCommands)

--- a/services/unison/goos/sync_darwin.go
+++ b/services/unison/goos/sync_darwin.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/ironstar-io/tokaido/conf"
 	unisontmpl "github.com/ironstar-io/tokaido/services/unison/templates"
 	"github.com/ironstar-io/tokaido/system/console"
 	"github.com/ironstar-io/tokaido/system/daemon"
@@ -29,7 +28,6 @@ type UnisonSvc struct {
 
 // NewUnisonSvc - Return a new instance of `UnisonSvc`.
 func NewUnisonSvc(syncName, syncDir string) UnisonSvc {
-	c := conf.GetConfig()
 	u, uErr := user.Current()
 	if uErr != nil {
 		log.Fatal(uErr)
@@ -40,7 +38,7 @@ func NewUnisonSvc(syncName, syncDir string) UnisonSvc {
 		SyncDir:     syncDir,
 		Filename:    getServiceFilename(syncName),
 		Filepath:    getServicePath(syncName),
-		Launchdpath: c.System.Syncsvc.Launchdpath,
+		Launchdpath: filepath.Join(fs.HomeDir(), "/Library/LaunchAgents/"),
 		Username:    u.Username,
 	}
 
@@ -59,7 +57,7 @@ func getServiceFilename(syncName string) string {
 }
 
 func getServicePath(syncName string) string {
-	return filepath.Join(conf.GetConfig().System.Syncsvc.Launchdpath, getServiceFilename(syncName))
+	return filepath.Join(filepath.Join(fs.HomeDir(), "/Library/LaunchAgents/"), getServiceFilename(syncName))
 }
 
 // CreateSyncFile - Create a .plist file for the unison service
@@ -122,10 +120,6 @@ func (s UnisonSvc) SyncServiceStatus() string {
 
 // CheckSyncService a verbose sync status check used for tok status
 func (s UnisonSvc) CheckSyncService() error {
-	if conf.GetConfig().System.Syncsvc.Enabled != true {
-		return nil
-	}
-
 	c := s.SyncServiceStatus()
 	if c == "running" {
 		console.Println("✅  Background sync service is running", "√")

--- a/services/unison/goos/sync_linux.go
+++ b/services/unison/goos/sync_linux.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ironstar-io/tokaido/conf"
 	unisontmpl "github.com/ironstar-io/tokaido/services/unison/templates"
 	"github.com/ironstar-io/tokaido/system/console"
 	"github.com/ironstar-io/tokaido/system/daemon"
@@ -36,8 +35,6 @@ type UnisonSvc struct {
 
 // NewUnisonSvc - Return a new instance of `UnisonSvc`.
 func NewUnisonSvc(syncName, syncDir string) UnisonSvc {
-	c := conf.GetConfig()
-
 	s := UnisonSvc{
 		SyncName:    syncName,
 		SyncDir:     syncDir,
@@ -54,7 +51,7 @@ func getServiceFilename(syncName string) string {
 }
 
 func getServicePath(syncName string) string {
-	return conf.GetConfig().Global.Syncsvc.Systemdpath + getServiceFilename(syncName)
+	return filepath.Join(fs.HomeDir(), "/.config/systemd/user/") + getServiceFilename(syncName)
 }
 
 // CreateSyncFile creates the systemd path (if necessary) and file
@@ -126,10 +123,6 @@ func (s UnisonSvc) StopSyncService() {
 
 // CheckSyncService a verbose sync status check used for tok status
 func (s UnisonSvc) CheckSyncService() error {
-	if conf.GetConfig().System.Syncsvc.Enabled != true {
-		return nil
-	}
-
 	c := s.SyncServiceStatus()
 	if c == "running" {
 		console.Println("✅  Background sync service is running", "√")

--- a/services/unison/goos/sync_linux.go
+++ b/services/unison/goos/sync_linux.go
@@ -43,7 +43,7 @@ func NewUnisonSvc(syncName, syncDir string) UnisonSvc {
 		SyncDir:     syncDir,
 		Filename:    getServiceFilename(syncName),
 		Filepath:    getServicePath(syncName),
-		Systemdpath: c.System.Syncsvc.Systemdpath,
+		Systemdpath: filepath.Join(fs.HomeDir(), "/.config/systemd/user/"),
 	}
 
 	return s
@@ -54,7 +54,7 @@ func getServiceFilename(syncName string) string {
 }
 
 func getServicePath(syncName string) string {
-	return conf.GetConfig().System.Syncsvc.Systemdpath + getServiceFilename(syncName)
+	return conf.GetConfig().Global.Syncsvc.Systemdpath + getServiceFilename(syncName)
 }
 
 // CreateSyncFile creates the systemd path (if necessary) and file

--- a/services/unison/service.go
+++ b/services/unison/service.go
@@ -3,7 +3,6 @@ package unison
 import (
 	"fmt"
 
-	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/services/unison/goos"
 	"github.com/ironstar-io/tokaido/system/console"
 )
@@ -23,30 +22,18 @@ func CreateSyncService(syncName, syncDir string) {
 
 // StopSyncService stop systemd sync service
 func StopSyncService(syncName string) {
-	if conf.GetConfig().System.Syncsvc.Enabled != true {
-		return
-	}
-
 	s := goos.NewUnisonSvc(syncName, "")
 	s.StopSyncService()
 }
 
 // RestartSyncService ...
 func RestartSyncService(syncName string) {
-	if conf.GetConfig().System.Syncsvc.Enabled != true {
-		return
-	}
-
 	s := goos.NewUnisonSvc(syncName, "")
 	s.RestartSyncService()
 }
 
 // UnloadSyncService will uninstall the sync service
 func UnloadSyncService(syncName string) {
-	if conf.GetConfig().System.Syncsvc.Enabled != true {
-		return
-	}
-
 	s := goos.NewUnisonSvc(syncName, "")
 	s.UnloadSyncService()
 }
@@ -65,10 +52,6 @@ func CheckSyncService(syncName string) error {
 
 // BackgroundServiceWarning - Check if the background sync service is running and warn if not
 func BackgroundServiceWarning(syncName string) {
-	if conf.GetConfig().System.Syncsvc.Enabled != true {
-		return
-	}
-
 	if !CheckBackgroundService(syncName) {
 		fmt.Println()
 		console.Println("⚠️  The background sync service is not running. Manually sync with `tok watch` or try running `tok up` again", "")


### PR DESCRIPTION
This PR removes sync service settings from being assignable within Tokaido. Previously these were being recorded in the project config (as bug via #185), but on considering this there's no reason to have these values be confiugrable anyway. 

They are only relevant where Unison is used and I don't think there's any good reason to make these configurable. The defaults will be correct in almost all use cases. Storing and tracking these values adds a fair bit of complexity however, hence the desire to remove them all together.

fixes #185