### PR TITLE
Add the ability to define a static port for the database

### DIFF
--- a/conf/editor.go
+++ b/conf/editor.go
@@ -282,7 +282,6 @@ Current Setting: [{{ .Current | green }}]
 	case 3:
 		if gprj.Xdebug.Enabled == true {
 			SetGlobalConfigValueByArgs([]string{"global", "project", "xdebug", "enabled", "false"})
-			// SetConfigValueByArgs([]string{"tokaido", "xdebug", "false"}, "project")
 		} else {
 			SetGlobalConfigValueByArgs([]string{"global", "project", "xdebug", "enabled", "true"})
 		}
@@ -459,6 +458,10 @@ func TokaidoPhpversionMenu() {
 
 // DatabaseMenu ...
 func DatabaseMenu() {
+	gprj, err := GetGlobalProjectSettings()
+	if err != nil {
+		panic(err)
+	}
 	fmt.Println(BgRed(White("!! WARNING !!")))
 	fmt.Println(BgRed(White("Changing your database configuration can completely break your database. We strongly recommend creating a `tok snapshot` first")))
 	fmt.Println(BgRed(White("!! WARNING !!")))
@@ -484,6 +487,12 @@ func DatabaseMenu() {
 			Current: GetConfig().Database.Mariadbconfig.Version,
 			Default: "10.3",
 			Detail:  "Set the MariaDB Version if MariaDB is used",
+		},
+		{
+			Name:    "Set static database port",
+			Type:    "value",
+			Current: strconv.Itoa(gprj.Database.Port),
+			Detail:  "Instead of using a dynamic random port number, always expose this project's database locally on a pre-defined port",
 		},
 		{
 			Name:    "« Main Menu",
@@ -542,8 +551,13 @@ func DatabaseMenu() {
 		reloadConfig()
 		DatabaseMenu()
 	case 3:
-		MainMenu()
+		res := newStringValue("Specify the port to always use for this project:")
+		SetGlobalConfigValueByArgs([]string{"global", "project", "database", "port", res})
+		reloadConfig()
+		DatabaseMenu()
 	case 4:
+		MainMenu()
+	case 5:
 		fmt.Println("Please note that if you have made config changes, you need to run `tok rebuild`")
 		os.Exit(0)
 	}

--- a/conf/set_config.go
+++ b/conf/set_config.go
@@ -72,13 +72,36 @@ func SetGlobalConfigValueByArgs(args []string) (err error) {
 			return fmt.Errorf("Error: too few arguments for global project config. Did you want 'xdebug'?")
 		}
 
+		p, err := GetGlobalProjectSettings()
+		if err != nil {
+			return err
+		}
+
+		if args[2] == "database" {
+			if len(args) < 4 {
+				return fmt.Errorf("Error: too few arguments for database port. Please specify 'port {number}'")
+			}
+
+			if args[3] != "port" {
+				return fmt.Errorf("Error: unknown argument '%s'. Expected 'port'", args[3])
+			}
+
+			dbPort, err := strconv.Atoi(args[4])
+			if err != nil {
+				return err
+			}
+			if dbPort < 1024 || dbPort > 65535 {
+				return fmt.Errorf("Error: you must specify an static database port between 1025 and 65535")
+			}
+
+			p.Database.Port = dbPort
+			WriteGlobalProjectSettings(p)
+			return nil
+		}
+
 		if args[2] == "xdebug" {
 			if len(args) < 4 {
 				return fmt.Errorf("Error: too few arguments for xdebug config. Please specify 'enabled {true/false}' or 'port {number}'")
-			}
-			p, err := GetGlobalProjectSettings()
-			if err != nil {
-				return err
 			}
 
 			if args[3] == "enabled" {
@@ -111,6 +134,7 @@ func SetGlobalConfigValueByArgs(args []string) (err error) {
 				WriteGlobalProjectSettings(p)
 				return nil
 			}
+
 			return nil
 		}
 	}

--- a/conf/struct.go
+++ b/conf/struct.go
@@ -2,8 +2,11 @@ package conf
 
 // Project is a singular entry of a project name and path used in global config
 type Project struct {
-	Name   string `yaml:"name,omitempty"`
-	Path   string `yaml:"path,omitempty"`
+	Name     string `yaml:"name,omitempty"`
+	Path     string `yaml:"path,omitempty"`
+	Database struct {
+		Port int `yaml:"port,omitempty"`
+	} `yaml:"database,omitempty"`
 	Xdebug struct {
 		Enabled bool `yaml:"enabled"`
 		FpmPort int  `yaml:"fpmport"`

--- a/services/docker/generate.go
+++ b/services/docker/generate.go
@@ -98,6 +98,11 @@ func UnmarshalledDefaults() conf.ComposeDotTok {
 	phpVersion := conf.GetConfig().Tokaido.Phpversion
 	syncservice := conf.GetConfig().Global.Syncservice
 
+	gprj, err := conf.GetGlobalProjectSettings()
+	if err != nil {
+		panic(err)
+	}
+
 	switch syncservice {
 	case "docker":
 		utils.DebugString("attaching repo to /tokaido/site folder using direct Docker mount")
@@ -153,7 +158,7 @@ func UnmarshalledDefaults() conf.ComposeDotTok {
 		}
 	}
 
-	err := yaml.Unmarshal(getDrupalSettings(), &tokStruct)
+	err = yaml.Unmarshal(getDrupalSettings(), &tokStruct)
 	if err != nil {
 		log.Fatalf("Error adding Drupal settings to Compose file: %v", err)
 	}
@@ -188,6 +193,13 @@ func UnmarshalledDefaults() conf.ComposeDotTok {
 	err = yaml.Unmarshal(dockertmpl.SetDatabase(dbImage, dbVersion), &tokStruct)
 	if err != nil {
 		log.Fatalf("Error generating database config: %v", err)
+	}
+
+	if gprj.Database.Port > 0 {
+		err = yaml.Unmarshal(dockertmpl.SetDatabasePort(fmt.Sprint(gprj.Database.Port)), &tokStruct)
+		if err != nil {
+			log.Fatalf("Error generating static database port: %v", err)
+		}
 	}
 
 	if conf.GetConfig().Services.Solr.Enabled {

--- a/services/docker/templates/compose.go
+++ b/services/docker/templates/compose.go
@@ -201,6 +201,14 @@ func SetDatabase(image, version string) []byte {
 `)
 }
 
+// SetDatabasePort assigns a static local port for the database
+func SetDatabasePort(port string) []byte {
+	return []byte(`services:
+  mysql:
+    ports:
+      - ` + port + `:3306`)
+}
+
 // SetUnisonVersion ...
 func SetUnisonVersion(version string) []byte {
 	return []byte(`services:


### PR DESCRIPTION
You can now specify a fixed port for MySQL or Mariadb to use with `tok config-set global project database port [number]` This will make the database container always available on your local system at that port number. This is a local setting, not committed back to your project repo.

resolves #189