### PR TITLE
set Tokaido to use pinned image tags, rather than 'edge' or 'stable'

### DIFF
--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -24,7 +24,7 @@ var RebuildCmd = &cobra.Command{
 		docker.Stop()
 		unison.UnloadSyncService(conf.GetConfig().Tokaido.Project.Name)
 
-		tok.Init(true, false, false)
+		tok.Init(true, false)
 
 		tok.InitMessage()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,7 +70,6 @@ func RootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug mode, command output is printed to the console")
 
 	OpenCmd.PersistentFlags().BoolVarP(&adminFlag, "admin", "", false, "Create a one-time admin login URL and open")
-	UpCmd.PersistentFlags().BoolVarP(&noPullImagesFlag, "no-pull-images", "", false, "Stop Tokaido from downloaded the latest Docker images")
 	TestCmd.PersistentFlags().BoolVarP(&useExistingDBFlag, "use-existing-db", "", false, "Run the test suite without recreating the database or temporary users. Note: this may cause test flakiness due to database having prior state.")
 	SnapshotNewCmd.PersistentFlags().StringVarP(&nameFlag, "name", "n", "", "Specify a name to be added to the snapshot name. If not specified, Tokaido will only use the current UTC date and time")
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -21,7 +21,7 @@ var UpCmd = &cobra.Command{
 		telemetry.SendCommand("up")
 		utils.CheckCmdHard("docker-compose")
 
-		tok.Init(conf.GetConfig().Tokaido.Yes, true, noPullImagesFlag)
+		tok.Init(conf.GetConfig().Tokaido.Yes, true)
 		tok.InitMessage()
 	},
 }

--- a/constants/images.go
+++ b/constants/images.go
@@ -1,6 +1,9 @@
 package constants
 
 const (
-	// ProxyStableVersion ...
-	ProxyStableVersion string = "1.11.0"
+	// StableVersion is the tag for all Tokaido images that are running in Ironstar Production environments at the time of this Tokaido release
+	StableVersion string = "stable"
+
+	// EdgeVersion is the tag for all Tokaido images that are running in Ironstar Non-Production environments at the time of this Tokaido release
+	EdgeVersion string = "1.11.0"
 )

--- a/initialize/main.go
+++ b/initialize/main.go
@@ -72,7 +72,7 @@ func readProjectConfig(command string) {
 	viper.SetDefault("Tokaido.Debug", viper.GetBool("debug"))
 	viper.SetDefault("Tokaido.Force", viper.GetBool("force"))
 	viper.SetDefault("Tokaido.Yes", viper.GetBool("yes"))
-	viper.SetDefault("Tokaido.Stability", "edge")
+	viper.SetDefault("Tokaido.Stability", constants.EdgeVersion)
 	viper.SetDefault("Tokaido.Dependencychecks", true)
 	viper.SetDefault("Tokaido.Enableemoji", emojiDefaults())
 	viper.SetDefault("Tokaido.Phpversion", "7.2")

--- a/services/docker/generate.go
+++ b/services/docker/generate.go
@@ -260,7 +260,7 @@ func UnmarshalledDefaults() conf.ComposeDotTok {
 	}
 
 	// Set our stability version
-	err = yaml.Unmarshal(dockertmpl.StabilityLevel(phpVersion, conf.GetConfig().Tokaido.Stability), &tokStruct)
+	err = yaml.Unmarshal(dockertmpl.ImageVersion(phpVersion, conf.GetConfig().Tokaido.Stability), &tokStruct)
 	if err != nil {
 		log.Fatalf("Error updating stability version for containers in Compose file: %v", err)
 	}

--- a/services/docker/templates/compose.go
+++ b/services/docker/templates/compose.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/ironstar-io/tokaido/conf"
+	"github.com/ironstar-io/tokaido/constants"
 	"github.com/ironstar-io/tokaido/system/fs"
 	homedir "github.com/mitchellh/go-homedir"
 )
@@ -56,41 +57,46 @@ func DrupalSettings(drupalRoot string, projectName string) []byte {
         PROJECT_NAME: ` + projectName)
 }
 
-// StabilityLevel ...
-func StabilityLevel(phpVersion, stability string) []byte {
+// ImageVersion ...
+func ImageVersion(phpVersion, stability string) []byte {
 	v := calcPhpVersionString(phpVersion)
+
+	imageVersion := constants.EdgeVersion
+	if stability == "stable" {
+		imageVersion = constants.StableVersion
+	}
 
 	if conf.GetConfig().Global.Syncservice == "fusion" {
 		return []byte(`services:
   sync:
-    image: tokaido/sync:` + stability + `
+    image: tokaido/sync:` + imageVersion + `
   syslog:
-    image: tokaido/syslog:` + stability + `
+    image: tokaido/syslog:` + imageVersion + `
   haproxy:
-    image: tokaido/haproxy:` + stability + `
+    image: tokaido/haproxy:` + imageVersion + `
   varnish:
-    image: tokaido/varnish:` + stability + `
+    image: tokaido/varnish:` + imageVersion + `
   nginx:
-    image: tokaido/nginx:` + stability + `
+    image: tokaido/nginx:` + imageVersion + `
   fpm:
-    image: tokaido/php` + v + `-fpm:` + stability + `
+    image: tokaido/php` + v + `-fpm:` + imageVersion + `
   drush:
-    image: tokaido/admin` + v + `-heavy:` + stability + ``)
+    image: tokaido/admin` + v + `-heavy:` + imageVersion + ``)
 	}
 
 	return []byte(`services:
   syslog:
-    image: tokaido/syslog:` + stability + `
+    image: tokaido/syslog:` + imageVersion + `
   haproxy:
-    image: tokaido/haproxy:` + stability + `
+    image: tokaido/haproxy:` + imageVersion + `
   varnish:
-    image: tokaido/varnish:` + stability + `
+    image: tokaido/varnish:` + imageVersion + `
   nginx:
-    image: tokaido/nginx:` + stability + `
+    image: tokaido/nginx:` + imageVersion + `
   fpm:
-    image: tokaido/php` + v + `-fpm:` + stability + `
+    image: tokaido/php` + v + `-fpm:` + imageVersion + `
   drush:
-    image: tokaido/admin` + v + `-heavy:` + stability + ``)
+    image: tokaido/admin` + v + `-heavy:` + imageVersion + ``)
 }
 
 // EnableSolr ...

--- a/services/proxy/struct.go
+++ b/services/proxy/struct.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/constants"
 )
 
@@ -42,7 +43,7 @@ func ComposeDefaults() []byte {
 	return []byte(`version: "2"
 services:
   proxy:
-    image: tokaido/proxy:` + constants.ProxyStableVersion + `
+    image: tokaido/proxy:` + conf.GetConfig().Tokaido.Stability + `
     ports:
       - "` + constants.ProxyPort + `:` + constants.ProxyPort + `"
     volumes:
@@ -72,7 +73,7 @@ services:
       - default
       - tokaido_proxy
   proxy:
-    image: tokaido/proxy:` + constants.ProxyStableVersion + `
+    image: tokaido/proxy:` + conf.GetConfig().Tokaido.Stability + `
     ports:
       - "` + constants.ProxyPort + `:` + constants.ProxyPort + `"
     volumes_from:

--- a/services/tok/init.go
+++ b/services/tok/init.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Init - The core run sheet of `tok up`
-func Init(yes, statuscheck, noPullImagesFlag bool) {
+func Init(yes, statuscheck bool) {
 	c := conf.GetConfig()
 	cs := "ASK"
 	if yes {
@@ -95,13 +95,6 @@ func Init(yes, statuscheck, noPullImagesFlag bool) {
 		siteVolName := "tok_" + conf.GetConfig().Tokaido.Project.Name + "_tokaido_site"
 		utils.StdoutStreamCmdDebug("docker", "run", "--rm", "-e", "AUTO_SYNC=false", "-v", conf.GetProjectPath()+":/tokaido/host-volume", "-v", siteVolName+":/tokaido/site", "tokaido/sync:stable")
 		console.SpinPersist(wo, "🚛", "Initial sync completed")
-	}
-
-	if noPullImagesFlag {
-		fmt.Println("    Not downloading the latest Docker images")
-	} else {
-		fmt.Println("🤖  Downloading the latest Docker images")
-		docker.PullImages()
 	}
 
 	// Configure TLS

--- a/services/tok/new.go
+++ b/services/tok/new.go
@@ -208,7 +208,7 @@ func New(args []string, requestTemplate string) {
 
 	// Start the environment
 	initialize.TokConfig("up")
-	Init(true, false, false)
+	Init(true, false)
 
 	// Run the post-up custom installation commands
 	l := len(template.PostUpCommands)


### PR DESCRIPTION
With this PR, Tokaido will use specific Docker image tags that correspond to that Tokaido release. 

For example, Tokaido 1.11.0 will use Docker Images tagged 1.11.0. 

We will still have the concept of "edge" and "stable" releases, as matched against which version of Tokaido is running in the Ironstar prod and non-prod clusters. 

This change enables us to remove the docker-pull functionality which takes unnecessary time during `up`, and will also enable us to offer more consistency between Tokaido versions. 