### PR TITLE
No exec on windows

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/ironstar-io/tokaido/conf"
 	"github.com/ironstar-io/tokaido/initialize"
 	"github.com/ironstar-io/tokaido/services/telemetry"
+	"github.com/ironstar-io/tokaido/system"
+	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +18,12 @@ var ConfigCmd = &cobra.Command{
 	Short: "An interactive Tokaido config editor",
 	Long:  "An interactive Tokaido config editor",
 	Run: func(cmd *cobra.Command, args []string) {
+		if system.CheckOS() == "windows" {
+			fmt.Println(aurora.Red("Sorry! The 'tok config' command isn't available on Windows. Please use `tok config-set` instead"))
+			fmt.Println("Please see the Full Tokaido Configuration Reference at https://docs.tokaido.io/en/docs/advanced/tokaido-config-reference for further detail.")
+			os.Exit(1)
+		}
+
 		initialize.TokConfig("config")
 		conf.ValidProjectRoot()
 		telemetry.SendCommand("config")

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,20 +1,30 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/ironstar-io/tokaido/initialize"
 	"github.com/ironstar-io/tokaido/services/docker"
 	"github.com/ironstar-io/tokaido/services/telemetry"
+	"github.com/ironstar-io/tokaido/system"
 	"github.com/ironstar-io/tokaido/system/ssh"
 	"github.com/ironstar-io/tokaido/utils"
+	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 )
 
 // ExecCmd - `tok exec`
 var ExecCmd = &cobra.Command{
 	Use:   "exec",
-	Short: "Execute a command inside the Tokaido shell (Drush) container",
-	Long:  "Execute a command inside the Tokaido shell (Drush) container using SSH. Alias to `ssh <project-name>.tok -C command`",
+	Short: "Execute a command inside the Tokaido SSH container",
+	Long:  "Execute a command inside the Tokaido SSH container. Alias to `ssh <project-name>.tok -C command`",
 	Run: func(cmd *cobra.Command, args []string) {
+		if system.CheckOS() == "windows" {
+			fmt.Println(aurora.Red("Sorry! The 'tok exec' command isn't available on Windows. Please use SSH instead"))
+			os.Exit(1)
+		}
+
 		initialize.TokConfig("exec")
 		utils.CheckCmdHard("docker-compose")
 		telemetry.SendCommand("exec")

--- a/constants/images.go
+++ b/constants/images.go
@@ -2,8 +2,8 @@ package constants
 
 const (
 	// StableVersion is the tag for all Tokaido images that are running in Ironstar Production environments at the time of this Tokaido release
-	StableVersion string = "stable"
+	StableVersion string = "1.11.1"
 
 	// EdgeVersion is the tag for all Tokaido images that are running in Ironstar Non-Production environments at the time of this Tokaido release
-	EdgeVersion string = "1.11.1"
+	EdgeVersion string = "1.12.0"
 )


### PR DESCRIPTION
disables `tok exec` in Windows because git bash dosen't support the terminal emulation, and a fix is currently out of scope.