### PR TITLE
implements support for custom template URLs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ironstar-io/tokaido/system/version"
 	"github.com/ironstar-io/tokaido/initialize"
+	"github.com/ironstar-io/tokaido/system/version"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/conf/struct.go
+++ b/conf/struct.go
@@ -21,9 +21,10 @@ type Telemetry struct {
 
 // Global contains all our global config settings that are saved in ~/.tok/global.yml
 type Global struct {
-	Syncservice string    `yaml:"syncservice,omitempty"`
-	Projects    []Project `yaml:"projects,omitempty"`
-	Telemetry   Telemetry `yaml:"telemetry,omitempty"`
+	Syncservice     string    `yaml:"syncservice,omitempty"`
+	Projects        []Project `yaml:"projects,omitempty"`
+	Telemetry       Telemetry `yaml:"telemetry,omitempty"`
+	CustomTemplates string    `yaml:"customTemplates,omitempty"`
 }
 
 // Config the application's configuration

--- a/services/docker/general.go
+++ b/services/docker/general.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/docker/docker/client"
 	"github.com/ironstar-io/tokaido/conf"
-	"github.com/ironstar-io/tokaido/utils"
 	"github.com/ironstar-io/tokaido/system/wsl"
+	"github.com/ironstar-io/tokaido/utils"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/viper"

--- a/services/tok/goos/choose_template_unix.go
+++ b/services/tok/goos/choose_template_unix.go
@@ -32,7 +32,6 @@ func ChooseTemplate(tp *types.Templates) (template types.Template) {
 {{ .Description | faint  }}
 
 Maintainer: {{ .Maintainer | faint }}
-URL: https://downloads.tokaido.io/packages/{{ .PackageFilename | faint }}
 `,
 	}
 

--- a/services/tok/types/main.go
+++ b/services/tok/types/main.go
@@ -11,6 +11,7 @@ type Template struct {
 	DrupalVersion   int      `yaml:"drupal_version"`
 	Maintainer      string   `yaml:"maintainer"`
 	Name            string   `yaml:"name"`
-	PackageFilename string   `yaml:"package_filename"`
+	PackageFilename string   `yaml:"package_filename,omitempty"`
+	PackageURL      string   `yaml:"package_url,omitempty"`
 	PostUpCommands  []string `yaml:"post_up_commands,omitempty"`
 }


### PR DESCRIPTION
This PR adds support for users to define their own custom templates when using `tok new`. 

To define your own templates, add a `customTemplates` URL To `~/.tok/global.yml`, such as:
> customTemplates: https://example.com/templates.yaml

The templates YAML file has the follow the same pattern as the [official templates.yaml file](http://downloads.tokaido.io/templates.yaml) but you now define a ` package_url` instead of `package_filename` to specify a full path to your own package. For example:
```
templates:
  - name: "custom-image"
    drupal_version: 9
    package_url: "https://example.com/drupal9-example-org.tar.gz"
    maintainer: my-organisation
    description: "a custom image only available to people who know the url"
    post_up_commands:
      - drush site-install -y minimal
```

The `package_url` needs to be publicly accessible and the package itself should be the root of a ready-to-start package. See [tokaido-drupal-package-builder](https://github.com/ironstar-io/tokaido-drupal-package-builder) and it's CircleCI file for examples of how to build these packages. 